### PR TITLE
Improve form accessibility

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -49,10 +49,10 @@
             </div>
           </div>
         </fieldset>
-        <fieldset class="input-wrapper">
+        <fieldset class="input-wrapper" aria-describedby="breathingDifficulties-description">
           <legend>Vaikeuksia hengittää</legend>
           <div class="options">
-            <em>Huom! Jos sinulla on hengitysvaikeuksia, ota heti yhteys terveydenhuoltoon.</em>
+            <em id="breathingDifficulties-description">Huom! Jos sinulla on hengitysvaikeuksia, ota heti yhteys terveydenhuoltoon.</em>
             <input id="breathingDifficulties-yes" type="radio" name="breathingDifficulties" value="yes">
             <label for="breathingDifficulties-yes">kyllä</label>
             <input id="breathingDifficulties-no" type="radio" name="breathingDifficulties" value="no">
@@ -89,10 +89,10 @@
       </div>
       <div class="question-group">
         <h2 class="question-group-title">Yleinen terveys</h2>
-        <fieldset class="input-wrapper">
+        <fieldset class="input-wrapper" aria-describedby="generalWellBeing-description">
           <legend>Millainen on yleisvointisi?</legend>
           <div class="options">
-            <em>Huom! Jos et jaksa nousta vuoteesta, ota heti yhteys terveydenhuoltoon.
+            <em id="generalWellBeing-description">Huom! Jos et jaksa nousta vuoteesta, ota heti yhteys terveydenhuoltoon.
             </em>
             <div class="option-wrapper">
               <input id="generalWellbeing-fine" type="radio" name="generalWellbeing" value="fine">


### PR DESCRIPTION
Updates to improve accessibility, based on these recommendations by Fotis

> input[type=number] is tricky. The inputs here are definitely numbers in that sense, but input type number seems to have a couple of accessibility issues (and the main annoying thing is that I can’t test them comprehensively). You might want to skip it altogether and use the recommendation at https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/

> For the fieldset labeled by “Millainen on yleisvointisi?“, there is a description under em. Consider adding an id to that em (e.g. generalWellBeing-description) and then adding aria-describedby="generalWellBeing-description" to the fieldset. This makes the note comparable to the one sighted users get.