### PR TITLE
Add target attribute to omaolo link to open it in a new window

### DIFF
--- a/frontend/embed/v1/public/index.html
+++ b/frontend/embed/v1/public/index.html
@@ -23,7 +23,7 @@
             kanssa.</p>
           <p>Jos epäilet sairastuneesi koronaviruksen aiheuttamaan tautiin ja haluat tehdä oirearvion, siirry Terveyden
             ja hyvinvoinnin laitoksen ylläpitämään <a
-              href="https://www.omaolo.fi/palvelut/oirearviot/649">Omaolo.fi-palveluun.</a></p>
+              href="https://www.omaolo.fi/palvelut/oirearviot/649" target="_blank">Omaolo.fi-palveluun.</a></p>
         </div>
       </div>
       <div id="form-info" class="form-info">


### PR DESCRIPTION
Based on Jarno's comment in the issue, I guess this might not work inside the iframe?