### PR TITLE
Validation hints on submit

### DIFF
--- a/frontend/embed/v1/public/index.html
+++ b/frontend/embed/v1/public/index.html
@@ -98,7 +98,7 @@
             <div class="options">
               <input id="headache-yes" type="radio" name="headache" value="yes" required />
               <label for="headache-yes">kyllä</label>
-              <input id="headache-no" type="radio" name="headache" value="no" />
+              <input id="headache-no" type="radio" name="headache" value="no" required />
               <label for="headache-no">ei</label>
             </div>
           </fieldset>


### PR DESCRIPTION
added input validation hints visible also via submit handler

added one missing `required` from an input
(if some option is missing it, and user selects the one, browser validation doesn't understand that it's valid) (at least in Chrome)

removed old input change handler