### PR TITLE
Add secret pepper for participant_id hashing

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -15,3 +15,6 @@ Manual steps required:
 1. For reasons unknown, the Athena result bucket needs to be set manually, even if it's defined in the Terraform config. For the `dev` env for instance, it'd be `s3://symptomradar-dev-storage-results/`.
 1. The setup also has CloudFront additional metrics enabled. Currently, this cannot be done through CLI or Terraform.
 1. It also creates an IAM user for deploying Lambdas and uploading to S3. However, access keys needs to be created using AWS Console.
+1. Some secrets are managed outside of Terraform, [so they don't end up as plain-text in the state file](https://www.terraform.io/docs/providers/aws/r/ssm_parameter.html). Set up the global secret pepper used for hashing `participant_id` before persistence:
+   1. `read SECRET && aws ssm put-parameter --type "SecureString" --name "/symptomradar/dev/secret-pepper" --value "$SECRET"`
+   1. `read SECRET && aws ssm put-parameter --type "SecureString" --name "/symptomradar/prod/secret-pepper" --value "$SECRET"`

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,8 +10,8 @@
 1. `terraform apply`
 1. `./scripts/deploy-frontend dev-tmp`
 
-For reasons unknown, the Athena result bucket needs to be set manually, even if it's defined in the Terraform config. For the `dev` env for instance, it'd be `s3://symptomradar-dev-storage-results/`.
+Manual steps required:
 
-The setup also has cloudfront additional metrics enabled. Currently, this cannot be done through cli or terraform.
-
-It also creates an IAM user for deploying Lambdas and uploading to S3. However, access keys needs to be created using AWS Console.
+1. For reasons unknown, the Athena result bucket needs to be set manually, even if it's defined in the Terraform config. For the `dev` env for instance, it'd be `s3://symptomradar-dev-storage-results/`.
+1. The setup also has CloudFront additional metrics enabled. Currently, this cannot be done through CLI or Terraform.
+1. It also creates an IAM user for deploying Lambdas and uploading to S3. However, access keys needs to be created using AWS Console.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -13,6 +13,7 @@ module "env_dev" {
   tags                   = merge(var.tags, { Environment = "dev" })
   frontend_domain        = "dev.oiretutka.fi"
   backend_domain         = "api.dev.oiretutka.fi"
+  known_hashing_pepper   = "D4GxgVVh0XQCrVb7FiyCal5ZgnRVkiVf"
   ssm_secrets_prefix     = "/symptomradar/dev/"
   s3_logs_bucket         = aws_s3_bucket.s3_logs.id
   backend_cors_allow_any = true
@@ -24,12 +25,13 @@ module "env_prod" {
   source    = "./modules/main"
   providers = { aws.us_east_1 = aws.us_east_1 } # this alias is needed because ACM is only available in the "us-east-1" region
 
-  name_prefix        = "${var.name_prefix}-prod"
-  tags               = merge(var.tags, { Environment = "prod" })
-  frontend_domain    = "www.oiretutka.fi"
-  backend_domain     = "api.oiretutka.fi"
-  ssm_secrets_prefix = "/symptomradar/prod/"
-  s3_logs_bucket     = aws_s3_bucket.s3_logs.id
+  name_prefix          = "${var.name_prefix}-prod"
+  tags                 = merge(var.tags, { Environment = "prod" })
+  frontend_domain      = "www.oiretutka.fi"
+  backend_domain       = "api.oiretutka.fi"
+  known_hashing_pepper = "vu2xkUW9iGUsIOUqjDEfarmSLmoRJnxB"
+  ssm_secrets_prefix   = "/symptomradar/prod/"
+  s3_logs_bucket       = aws_s3_bucket.s3_logs.id
 }
 
 # Pass along any output from the instantiated module

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -13,6 +13,7 @@ module "env_dev" {
   tags                   = merge(var.tags, { Environment = "dev" })
   frontend_domain        = "dev.oiretutka.fi"
   backend_domain         = "api.dev.oiretutka.fi"
+  ssm_secrets_prefix     = "/symptomradar/dev/"
   s3_logs_bucket         = aws_s3_bucket.s3_logs.id
   backend_cors_allow_any = true
   frontend_password      = var.frontend_password
@@ -23,11 +24,12 @@ module "env_prod" {
   source    = "./modules/main"
   providers = { aws.us_east_1 = aws.us_east_1 } # this alias is needed because ACM is only available in the "us-east-1" region
 
-  name_prefix     = "${var.name_prefix}-prod"
-  tags            = merge(var.tags, { Environment = "prod" })
-  frontend_domain = "www.oiretutka.fi"
-  backend_domain  = "api.oiretutka.fi"
-  s3_logs_bucket  = aws_s3_bucket.s3_logs.id
+  name_prefix        = "${var.name_prefix}-prod"
+  tags               = merge(var.tags, { Environment = "prod" })
+  frontend_domain    = "www.oiretutka.fi"
+  backend_domain     = "api.oiretutka.fi"
+  ssm_secrets_prefix = "/symptomradar/prod/"
+  s3_logs_bucket     = aws_s3_bucket.s3_logs.id
 }
 
 # Pass along any output from the instantiated module

--- a/infra/modules/main/backend.tf
+++ b/infra/modules/main/backend.tf
@@ -34,6 +34,7 @@ module "backend_api" {
     BUCKET_NAME_STORAGE   = aws_s3_bucket.storage.id
     CORS_ALLOW_ORIGIN     = var.backend_cors_allow_any ? "*" : "https://${var.frontend_domain}"
     SECRET_HASHING_PEPPER = random_string.secret_hashing_pepper.result
+    SSM_SECRETS_PREFIX    = var.ssm_secrets_prefix
   }
 }
 
@@ -71,6 +72,13 @@ resource "aws_iam_policy" "backend_api" {
         "arn:aws:s3:::${aws_s3_bucket.storage.id}/*"
       ],
       "Effect": "Allow"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameters"
+      ],
+      "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_secrets_prefix}secret-pepper"
     }
   ]
 }

--- a/infra/modules/main/backend.tf
+++ b/infra/modules/main/backend.tf
@@ -10,12 +10,6 @@ resource "aws_s3_bucket" "backend_code" {
 
 }
 
-# Create random, secret pepper we can use for hashing
-resource "random_string" "secret_hashing_pepper" {
-  length  = 32
-  special = false
-}
-
 # Implements the Lambda API processing requests from the web
 module "backend_api" {
   source    = "../aws_lambda_api"
@@ -31,10 +25,10 @@ module "backend_api" {
   api_gateway_cloudwatch_metrics = true
 
   function_env_vars = {
-    BUCKET_NAME_STORAGE   = aws_s3_bucket.storage.id
-    CORS_ALLOW_ORIGIN     = var.backend_cors_allow_any ? "*" : "https://${var.frontend_domain}"
-    SECRET_HASHING_PEPPER = random_string.secret_hashing_pepper.result
-    SSM_SECRETS_PREFIX    = var.ssm_secrets_prefix
+    BUCKET_NAME_STORAGE  = aws_s3_bucket.storage.id
+    CORS_ALLOW_ORIGIN    = var.backend_cors_allow_any ? "*" : "https://${var.frontend_domain}"
+    KNOWN_HASHING_PEPPER = var.known_hashing_pepper
+    SSM_SECRETS_PREFIX   = var.ssm_secrets_prefix
   }
 }
 

--- a/infra/modules/main/variables.tf
+++ b/infra/modules/main/variables.tf
@@ -10,6 +10,10 @@ variable "backend_domain" {
   description = "Full domain name under which the backend should be made available on the Internet"
 }
 
+variable "ssm_secrets_prefix" {
+  description = "Key prefix under which the secrets for this env are stored in AWS Systems Manager Parameter Store (SSM)"
+}
+
 variable "tags" {
   description = "AWS Tags to add to all resources created (where possible); see https://aws.amazon.com/answers/account-management/aws-tagging-strategies/"
   type        = map(string)

--- a/infra/modules/main/variables.tf
+++ b/infra/modules/main/variables.tf
@@ -10,6 +10,10 @@ variable "backend_domain" {
   description = "Full domain name under which the backend should be made available on the Internet"
 }
 
+variable "known_hashing_pepper" {
+  description = "To preserve privacy, participant_id's are hashed before storage; this controls the public part of the pepper"
+}
+
 variable "ssm_secrets_prefix" {
   description = "Key prefix under which the secrets for this env are stored in AWS Systems Manager Parameter Store (SSM)"
 }

--- a/src/backend/main.test.ts
+++ b/src/backend/main.test.ts
@@ -51,14 +51,12 @@ const persistedResponseSample: BackendResponseModelT = {
 
 describe('prepareResponseForStorage()', () => {
   it('works', () => {
-    expect(
-      prepareResponseForStorage(
-        incomingResponseSample,
-        'FI',
-        () => cannedUuid,
-        () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
-      ),
-    ).toEqual(persistedResponseSample);
+    return prepareResponseForStorage(
+      incomingResponseSample,
+      'FI',
+      () => cannedUuid,
+      () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
+    ).then(r => expect(r).toEqual(persistedResponseSample));
   });
 });
 

--- a/src/backend/main.test.ts
+++ b/src/backend/main.test.ts
@@ -1,0 +1,69 @@
+import { FrontendResponseModelT, BackendResponseModelT } from '../common/model';
+import { prepareResponseForStorage, getStorageKey } from './main';
+
+const cannedUuid = '5fa8764a-7337-11ea-96ca-d38ac3d1909b';
+const incomingResponseSample: FrontendResponseModelT = {
+  participant_id: 'b087641b-80e8-419e-9b7a-3b47c0a770d8',
+  fever: 'no',
+  cough: 'mild',
+  breathing_difficulties: 'no',
+  muscle_pain: 'no',
+  headache: 'no',
+  sore_throat: 'no',
+  rhinitis: 'no',
+  stomach_issues: 'no',
+  sensory_issues: 'no',
+  healthcare_contact: 'no',
+  general_wellbeing: 'fine',
+  duration: '1', // or null
+  longterm_medication: 'no',
+  smoking: 'no',
+  corona_suspicion: 'no',
+  age_group: '20',
+  gender: 'other',
+  postal_code: '00520',
+};
+const persistedResponseSample: BackendResponseModelT = {
+  age_group: '20',
+  app_version: 'v1.2',
+  breathing_difficulties: 'no',
+  corona_suspicion: 'no',
+  cough: 'mild',
+  country_code: 'FI',
+  duration: 1,
+  fever: 'no',
+  gender: 'other',
+  general_wellbeing: 'fine',
+  headache: 'no',
+  healthcare_contact: 'no',
+  longterm_medication: 'no',
+  muscle_pain: 'no',
+  participant_id: 'v7vNU2UYRUXvmGPN/kUPlIgKY8Gr6Gbq9qYfJC+5CCU=',
+  postal_code: '00520',
+  response_id: cannedUuid,
+  rhinitis: 'no',
+  sensory_issues: 'no',
+  smoking: 'no',
+  sore_throat: 'no',
+  stomach_issues: 'no',
+  timestamp: '2020-03-31T10:08:00.000Z', // note the rounding to minute precision
+};
+
+describe('prepareResponseForStorage()', () => {
+  it('works', () => {
+    expect(
+      prepareResponseForStorage(
+        incomingResponseSample,
+        'FI',
+        () => cannedUuid,
+        () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
+      ),
+    ).toEqual(persistedResponseSample);
+  });
+});
+
+describe('getStorageKey()', () => {
+  it('works', () => {
+    expect(getStorageKey(persistedResponseSample)).toEqual(`responses/raw/2020-03-31/10:08:00.000Z/${cannedUuid}.json`);
+  });
+});

--- a/src/backend/main.test.ts
+++ b/src/backend/main.test.ts
@@ -38,7 +38,7 @@ const persistedResponseSample: BackendResponseModelT = {
   healthcare_contact: 'no',
   longterm_medication: 'no',
   muscle_pain: 'no',
-  participant_id: 'v7vNU2UYRUXvmGPN/kUPlIgKY8Gr6Gbq9qYfJC+5CCU=',
+  participant_id: 'gJHfWrLSp+DHWEZHponianQCdWSR9svvD5niz9rRM1U=',
   postal_code: '00520',
   response_id: cannedUuid,
   rhinitis: 'no',
@@ -54,6 +54,7 @@ describe('prepareResponseForStorage()', () => {
     return prepareResponseForStorage(
       incomingResponseSample,
       'FI',
+      Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,
       () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
     ).then(r => expect(r).toEqual(persistedResponseSample));

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -14,16 +14,19 @@ if (!knownPepper) throw new Error('Hashing pepper missing from environment');
 
 // Saves the given response into our storage bucket
 export function storeResponseInS3(response: FrontendResponseModelT, countryCode: string) {
-  const r = prepareResponseForStorage(response, countryCode);
-  console.log('About to store response', r);
-  return s3
-    .putObject({
-      Bucket: storageBucket,
-      Key: getStorageKey(r),
-      Body: JSON.stringify(r),
-      ACL: 'private',
+  return Promise.resolve()
+    .then(() => prepareResponseForStorage(response, countryCode))
+    .then(r => {
+      console.log('About to store response', r);
+      return s3
+        .putObject({
+          Bucket: storageBucket,
+          Key: getStorageKey(r),
+          Body: JSON.stringify(r),
+          ACL: 'private',
+        })
+        .promise();
     })
-    .promise()
     .then(() => {}); // don't promise any value, just the success of the operation
 }
 
@@ -34,20 +37,22 @@ export function prepareResponseForStorage(
   // Allow overriding non-deterministic parts in test code:
   uuid: () => string = uuidV4,
   timestamp = Date.now,
-) {
-  const meta = {
-    response_id: uuid(),
-    participant_id: hash(response.participant_id, knownPepper), // to preserve privacy, hash the participant_id before storing it, so after opening up the dataset, malicious actors can't submit more responses that pretend to belong to a previous participant
-    timestamp: new Date(timestamp()) // for security, don't trust browser clock, as it may be wrong or fraudulent
-      .toISOString()
-      .replace(/:..\..*/, ':00.000Z'), // to preserve privacy, intentionally reduce precision of the timestamp
-    app_version: 'v1.2', // TODO: This should be set by the deploy process, not hard-coded!
-    country_code: countryCode,
-    postal_code: mapPostalCode(response).postal_code, // to protect the privacy of participants from very small postal code areas, they are merged into larger ones, based on known population data
-    duration: response.duration === null ? null : parseInt(response.duration),
-  };
-  const model: BackendResponseModelT = { ...meta, ...response, ...meta }; // the double "...meta" is just for vanity: we want the meta-fields to appear first in the JSON representation
-  return assertIs(BackendResponseModel)(model); // ensure we still pass runtime validations as well
+): Promise<BackendResponseModelT> {
+  return Promise.resolve().then(() => {
+    const meta = {
+      response_id: uuid(),
+      participant_id: hash(response.participant_id, knownPepper), // to preserve privacy, hash the participant_id before storing it, so after opening up the dataset, malicious actors can't submit more responses that pretend to belong to a previous participant
+      timestamp: new Date(timestamp()) // for security, don't trust browser clock, as it may be wrong or fraudulent
+        .toISOString()
+        .replace(/:..\..*/, ':00.000Z'), // to preserve privacy, intentionally reduce precision of the timestamp
+      app_version: 'v1.2', // TODO: This should be set by the deploy process, not hard-coded!
+      country_code: countryCode,
+      postal_code: mapPostalCode(response).postal_code, // to protect the privacy of participants from very small postal code areas, they are merged into larger ones, based on known population data
+      duration: response.duration === null ? null : parseInt(response.duration),
+    };
+    const model: BackendResponseModelT = { ...meta, ...response, ...meta }; // the double "...meta" is just for vanity: we want the meta-fields to appear first in the JSON representation
+    return assertIs(BackendResponseModel)(model); // ensure we still pass runtime validations as well
+  });
 }
 
 // Produces the key under which this response should be stored in S3

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1,8 +1,8 @@
 import * as AWS from 'aws-sdk';
 import { createHash } from 'crypto';
 import { v4 as uuidV4 } from 'uuid';
+import { assertIs, BackendResponseModel, BackendResponseModelT, FrontendResponseModelT } from '../common/model';
 import { mapPostalCode } from './postalCode';
-import { FrontendResponseModelT, BackendResponseModelT, assertIs, BackendResponseModel } from '../common/model';
 
 const s3: AWS.S3 = new AWS.S3({ apiVersion: '2006-03-01' });
 const bucket = process.env.BUCKET_NAME_STORAGE || '';
@@ -28,13 +28,19 @@ export function storeResponseInS3(response: FrontendResponseModelT, countryCode:
 }
 
 // Takes a response from the frontend, scrubs it clean, and adds fields required for storing it
-export function prepareResponseForStorage(response: FrontendResponseModelT, countryCode: string) {
+export function prepareResponseForStorage(
+  response: FrontendResponseModelT,
+  countryCode: string,
+  // Allow overriding non-deterministic parts in test code:
+  uuid: () => string = uuidV4,
+  timestamp = Date.now,
+) {
   const meta = {
-    response_id: uuidV4(),
+    response_id: uuid(),
     participant_id: createHash('sha256') // to preserve privacy, hash the participant_id before storing it, so after opening up the dataset, malicious actors can't submit more responses that pretend to belong to a previous participant
       .update(response.participant_id + pepper) // include a global but secret pepper, so the resulting hashes are harder (or impossible) to reverse
       .digest('base64'), // e.g. "3085e05e-6f64-11ea-9f12-3b5bbd3456ee" => "K/FwCDUHL3iVb9JAMBdSEurw4rWuO/iJmcIWCn2B++s="
-    timestamp: new Date() // for security, don't trust browser clock, as it may be wrong or fraudulent
+    timestamp: new Date(timestamp()) // for security, don't trust browser clock, as it may be wrong or fraudulent
       .toISOString()
       .replace(/:..\..*/, ':00.000Z'), // to preserve privacy, intentionally reduce precision of the timestamp
     app_version: 'v1.2', // TODO: This should be set by the deploy process, not hard-coded!
@@ -47,7 +53,7 @@ export function prepareResponseForStorage(response: FrontendResponseModelT, coun
 }
 
 // Produces the key under which this response should be stored in S3
-function getStorageKey(response: BackendResponseModelT): string {
+export function getStorageKey(response: BackendResponseModelT): string {
   const [date, time] = response.timestamp.split('T');
   return `responses/raw/${date}/${time}/${response.response_id}.json`;
 }

--- a/src/backend/secrets.ts
+++ b/src/backend/secrets.ts
@@ -1,0 +1,16 @@
+import * as AWS from 'aws-sdk';
+
+const ssm = new AWS.SSM(); // note: for local development, you may need to: AWS.config.update({ region: 'eu-west-1' });
+
+// Fetches a correctly prefixed secret value from AWS Systems Manager Parameter Store (SSM)
+export function getSecret(name: 'secret-pepper') {
+  const fullName = process.env.SSM_SECRETS_PREFIX + name;
+  return ssm
+    .getParameters({
+      Names: [fullName],
+      WithDecryption: true,
+    })
+    .promise()
+    .then(data => (data.Parameters || [])[0].Value || '')
+    .catch(err => Promise.reject(new Error(`Couldn't get secret "${fullName}" (caused by\n${err}\n)`)));
+}

--- a/src/backend/secrets.ts
+++ b/src/backend/secrets.ts
@@ -5,6 +5,7 @@ const ssm = new AWS.SSM(); // note: for local development, you may need to: AWS.
 // Fetches a correctly prefixed secret value from AWS Systems Manager Parameter Store (SSM)
 export function getSecret(name: 'secret-pepper') {
   const fullName = process.env.SSM_SECRETS_PREFIX + name;
+  console.log(`Getting secret "${fullName}"`);
   return ssm
     .getParameters({
       Names: [fullName],

--- a/src/index-backend.ts
+++ b/src/index-backend.ts
@@ -46,7 +46,7 @@ if (process.argv[0].match(/\/ts-node$/)) {
   };
   Promise.resolve(test)
     .then(assertIs(FrontendResponseModel))
-    .then(res => prepareResponseForStorage(res, 'FI'))
+    .then(res => prepareResponseForStorage(res, 'FI', Promise.resolve('fake-secret-pepper')))
     .catch(err => err)
     .then(res => console.log(res));
 }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -6,4 +6,4 @@ import '@testing-library/jest-dom/extend-expect';
 
 // Ensure a test-friendly mock environment
 process.env.BUCKET_NAME_STORAGE = 'non-existing-bucket-for-test-suite';
-process.env.SECRET_HASHING_PEPPER = 'D4GxgVVh0XQCrVb7FiyCal5ZgnRVkiVf'; // despite the name, this isn't actually secret; see https://github.com/futurice/symptomradar/issues/157
+process.env.KNOWN_HASHING_PEPPER = 'D4GxgVVh0XQCrVb7FiyCal5ZgnRVkiVf'; // this is env-specific; in the test suite, we use the "dev" one

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+
+// Ensure a test-friendly mock environment
+process.env.BUCKET_NAME_STORAGE = 'non-existing-bucket-for-test-suite';
+process.env.SECRET_HASHING_PEPPER = 'D4GxgVVh0XQCrVb7FiyCal5ZgnRVkiVf'; // despite the name, this isn't actually secret; see https://github.com/futurice/symptomradar/issues/157


### PR DESCRIPTION
This PR splits the global pepper used for `participant_id` hashing into two parts:

* The known pepper, which is the one we've been using thus far. It hasn't really been secret, so for clarity, it's now included directly in the relevant part of Terraform config.
* The secret pepper, which is stored separately from the codebase, Terraform config, and Lambda environments, in AWS Systems Manager Parameter Store.

Using these two together (see a71a182 for the most important change) we'll ensure that even if someone was able to produce a rainbow table of all existing UUID's (not feasible), including our pre-existing pepper (even less feasible), they still would not be able to reverse that into the original UUID (which itself doesn't really identify participants to any meaningful degree). But you know, to make doubly-triply sure.

Closes #157

This will be followed up by a manual re-hashing of all `participant_id`s recorded with just the known pepper, to ensure that the same plaintext `participant_id` will map to the same hashed one in the future as well.