### PR TITLE
Pin prod infra to release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,15 @@ If you find a security related issue in our service, please contact datadeski@hs
 - Ensure `dev` has deployed the release you're planning to put out
 - [Test that basic data collection works directly](https://dev.oiretutka.fi/embed/v1/) and/or [embedded](https://www.hs.fi/datajournalismi/art-2000006450733.html)
 - Take a peek at the `dev` overview dashboard on CloudWatch and make sure everything looks fine
+- Run `terraform apply` to ensure there's no unapplied changes
+- Release the version pin for `module "env_prod"` in `infra/main.tf` (that is, remove the `?ref=vX.Y` part from the module source string)
+- Run `terraform apply` again, and apply any changes to prod (don't do this without knowing what you're doing, though; it's prod infrastructure!)
 - Consult the "N commits to master since this release" link in [releases](https://github.com/futurice/symptomradar/releases) and write release notes
 - Create the release on GitHub
 - Check that the [related action](https://github.com/futurice/symptomradar/actions?query=workflow%3A%22Deploy+PROD%22) completes successfully
 - [Test that basic data collection works directly](https://www.oiretutka.fi/embed/v1/) and/or [embedded](https://www.hs.fi/kotimaa/art-2000006452379.html)
 - Take a peek at the `prod` overview dashboard on CloudWatch and make sure everything looks fine
+- Set the version pin back to `infra/main.tf`, pointing to the newly created release
 
 # MIT License
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -22,7 +22,9 @@ module "env_dev" {
 
 # Implements an instance of the app, for a specific env
 module "env_prod" {
-  source    = "./modules/main"
+  # IMPORTANT: The prod environment is pinned to the latest release version, so it won't change during normal development.
+  # See infra/README.md for how to deal with it during releases, when actual prod infra changes need to be made.
+  source    = "git::ssh://git@github.com/futurice/symptomradar.git//infra/modules/main?ref=v1.3"
   providers = { aws.us_east_1 = aws.us_east_1 } # this alias is needed because ACM is only available in the "us-east-1" region
 
   name_prefix          = "${var.name_prefix}-prod"


### PR DESCRIPTION
This allows us to keep iterating on the dev side of things, without accidentally `terraform apply`ing to prod.