### PR TITLE
add iam policy for athena developers

### DIFF
--- a/infra/athena_iam.tf
+++ b/infra/athena_iam.tf
@@ -70,6 +70,9 @@ resource "aws_iam_group_policy" "athena_developers" {
 EOF
 }
 
+# This policy allows the read-only Athena users to also manage their own passwords, access keys & MFA devices; see:
+# - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-pass-accesskeys-ssh.html
+# - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html
 data "aws_iam_policy_document" "iam_fine_tune" {
   statement {
     sid = "AllowViewAccountInfo"

--- a/infra/athena_iam.tf
+++ b/infra/athena_iam.tf
@@ -69,3 +69,91 @@ resource "aws_iam_group_policy" "athena_developers" {
 }
 EOF
 }
+
+data "aws_iam_policy_document" "iam_fine_tune" {
+  statement {
+    sid = "AllowViewAccountInfo"
+    actions = [
+      "iam:ListAccountAliases",
+      "iam:GetAccountPasswordPolicy",
+      "iam:GetAccountSummary",
+      "iam:ListUsers",
+      "iam:ListVirtualMFADevices"
+    ]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+  statement {
+    sid = "AllowManageOwnAccount"
+    actions = [
+      "iam:ChangePassword",
+      "iam:GetUser",
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:ListAccessKeys",
+      "iam:UpdateAccessKey",
+      "iam:CreateLoginProfile",
+      "iam:DeleteLoginProfile",
+      "iam:GetLoginProfile",
+      "iam:UpdateLoginProfile"
+    ]
+    resources = ["arn:aws:iam::*:user/$${aws:username}"]
+    effect    = "Allow"
+  }
+  statement {
+    sid = "AllowManageOwnVirtualMFADevice"
+    actions = [
+      "iam:DeactivateMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ListMFADevices",
+      "iam:ResyncMFADevice"
+    ]
+    resources = [
+      "arn:aws:iam::*:user/$${aws:username}"
+    ]
+    effect = "Allow"
+  }
+  statement {
+    sid = "AllowManageOwnUserMFA"
+    actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:DeleteVirtualMFADevice"
+    ]
+    resources = [
+      "arn:aws:iam::*:mfa/$${aws:username}"
+    ]
+    effect = "Allow"
+  }
+  statement {
+    sid = "DenyAllExceptListedIfNoMFA"
+    not_actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:GetUser",
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+      "iam:ResyncMFADevice",
+      "sts:GetSessionToken"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "BoolIfExists"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["false"]
+    }
+    effect = "Deny"
+
+
+  }
+}
+
+resource "aws_iam_policy" "iam_fine_tune" {
+  name   = "${var.name_prefix}-iam-fine-tune"
+  policy = data.aws_iam_policy_document.iam_fine_tune.json
+}
+
+resource "aws_iam_group_policy_attachment" "iam_fine_tune_athena_user" {
+  group      = aws_iam_group.athena_developers.name
+  policy_arn = aws_iam_policy.iam_fine_tune.arn
+}
+

--- a/infra/athena_iam.tf
+++ b/infra/athena_iam.tf
@@ -142,8 +142,6 @@ data "aws_iam_policy_document" "iam_fine_tune" {
       values   = ["false"]
     }
     effect = "Deny"
-
-
   }
 }
 
@@ -156,4 +154,3 @@ resource "aws_iam_group_policy_attachment" "iam_fine_tune_athena_user" {
   group      = aws_iam_group.athena_developers.name
   policy_arn = aws_iam_policy.iam_fine_tune.arn
 }
-


### PR DESCRIPTION
Reference for iam fine tune policies
* https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-pass-accesskeys-ssh.html
* https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html