### PR TITLE
Add white background color for the embed

### DIFF
--- a/src/frontend/embed/v1/index.css
+++ b/src/frontend/embed/v1/index.css
@@ -16,6 +16,7 @@ body {
   font-size: 16px;
   line-height: 1.25;
   color: #000000;
+  background-color: #ffffff;
 }
 
 [tabindex='-1']:focus {


### PR DESCRIPTION
This makes it look nicer in HS apps with dark mode

Fixes this: 
![Screenshot_20200406-213055_Helsingin Sanomat](https://user-images.githubusercontent.com/6113341/78594475-0df3ff80-7851-11ea-82ad-80c4d3937b77.jpg)
