### PR TITLE
Athena script using the example *WIP*

### DIFF
--- a/scripts/athena-fetch.js
+++ b/scripts/athena-fetch.js
@@ -1,0 +1,39 @@
+const ENV = "dev" // or prod
+
+const DATABASE = `symptomradar_${ENV}_storage`
+const OUTPUT_LOCATION = `s3://symptomradar-${ENV}-storage-results/query/`
+const query = "SELECT * FROM responses LIMIT 3;"
+
+const AthenaExpress = require("athena-express"),
+    aws = require("aws-sdk"),
+    awsCredentials = {
+        region: "eu-west-1"
+    };
+
+aws.config.update(awsCredentials);
+
+const athenaExpressConfig = {
+    aws,
+    s3: OUTPUT_LOCATION,
+    formatJson: true,
+    ignoreEmpty: true,
+    getStats: true
+};
+
+const athenaExpress = new AthenaExpress(athenaExpressConfig);
+
+(async () => {
+    let myQuery = {
+        sql: query,
+        db: DATABASE
+    };
+
+    try {
+        let results = await athenaExpress.query(myQuery);
+        console.log(results);
+    } catch (error) {
+        console.log(error);
+    }
+})();
+
+console.log('Done');


### PR DESCRIPTION
I can't get this to run locally so I can't test the output

All queries either cause an error(, or never finish if I fill in my credentials into the awsCredentials)

query: "SHOW SCHEMAS;"
error:
```Error: InvalidRequestException: Unable to verify/create output bucket symptomradar-dev-storage-results
    at AthenaExpress.query (/Users/enik/Documents/symptomradar/node_modules/athena-express/lib/athenaExpress.js:81:10)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

query: "SELECT * FROM responses LIMIT 3;”
error:
```
Error: InvalidRequestException: Unable to verify/create output bucket symptomradar-dev-storage-results
    at AthenaExpress.query (/Users/enik/Documents/symptomradar/node_modules/athena-express/lib/athenaExpress.js:81:10)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```