### PR TITLE
Fix standalone site routing

### DIFF
--- a/infra/modules/aws_reverse_proxy/cloudfront.tf
+++ b/infra/modules/aws_reverse_proxy/cloudfront.tf
@@ -59,7 +59,7 @@ resource "aws_cloudfront_distribution" "this" {
     # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-delete-replicas.html
     lambda_function_association {
       event_type = "origin-response" # one of [ viewer-request, origin-request, viewer-response, origin-response ]
-      lambda_arn = "${aws_lambda_function.origin_response_temp.arn}:${aws_lambda_function.origin_response_temp.version}"
+      lambda_arn = "${aws_lambda_function.origin_response.arn}:${aws_lambda_function.origin_response.version}"
     }
   }
 

--- a/infra/modules/aws_reverse_proxy/cloudfront.tf
+++ b/infra/modules/aws_reverse_proxy/cloudfront.tf
@@ -58,8 +58,8 @@ resource "aws_cloudfront_distribution" "this" {
     # Note: This will make the Lambda undeletable, as long as this distribution/association exists
     # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-delete-replicas.html
     lambda_function_association {
-      event_type = "viewer-response" # one of [ viewer-request, origin-request, viewer-response, origin-response ]
-      lambda_arn = "${aws_lambda_function.viewer_response.arn}:${aws_lambda_function.viewer_response.version}"
+      event_type = "origin-response" # one of [ viewer-request, origin-request, viewer-response, origin-response ]
+      lambda_arn = "${aws_lambda_function.origin_response_temp.arn}:${aws_lambda_function.origin_response_temp.version}"
     }
   }
 

--- a/infra/modules/aws_reverse_proxy/lambda.tf
+++ b/infra/modules/aws_reverse_proxy/lambda.tf
@@ -78,21 +78,6 @@ resource "aws_lambda_function" "origin_response" {
   tags             = var.tags
 }
 
-# TODO: DELME
-resource "aws_lambda_function" "origin_response_temp" {
-  provider = aws.us_east_1 # This alias is needed because ACM is only available in the "us-east-1" region
-
-  filename         = data.archive_file.lambda_zip.output_path
-  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
-  function_name    = "${var.name_prefix}-edge-lambda-response-temp"
-  role             = aws_iam_role.this.arn
-  description      = "${var.comment_prefix}${var.site_domain} (response handler)"
-  handler          = "lambda.origin_response"
-  runtime          = "nodejs12.x"
-  publish          = true # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function ARN must reference a specific function version. (The ARN must end with the version number.)
-  tags             = var.tags
-}
-
 # Allow Lambda@Edge to invoke our functions
 resource "aws_iam_role" "this" {
   name = var.name_prefix

--- a/infra/modules/aws_reverse_proxy/lambda.tf
+++ b/infra/modules/aws_reverse_proxy/lambda.tf
@@ -8,6 +8,7 @@ locals {
     override_response_code   = var.override_response_code
     override_response_status = var.override_response_status
     override_response_body   = var.override_response_body
+    override_only_on_code    = var.override_only_on_code
   }
 }
 

--- a/infra/modules/aws_reverse_proxy/lambda.tf
+++ b/infra/modules/aws_reverse_proxy/lambda.tf
@@ -64,6 +64,22 @@ resource "aws_lambda_function" "viewer_request" {
   tags             = var.tags
 }
 
+resource "aws_lambda_function" "origin_response_temp" {
+  provider = aws.us_east_1 # This alias is needed because ACM is only available in the "us-east-1" region
+
+  filename         = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  function_name    = "${var.name_prefix}-edge-lambda-response-temp"
+  role             = aws_iam_role.this.arn
+  description      = "${var.comment_prefix}${var.site_domain} (response handler)"
+  handler          = "lambda.origin_response"
+  runtime          = "nodejs12.x"
+  publish          = true # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function ARN must reference a specific function version. (The ARN must end with the version number.)
+  tags             = var.tags
+}
+
+# TODO: Once the above, new version of this function has been fully rolled out, this old function can be removed.
+# After that, the "-temp" suffix should be removed using the same process.
 resource "aws_lambda_function" "viewer_response" {
   provider = aws.us_east_1 # This alias is needed because ACM is only available in the "us-east-1" region
 

--- a/infra/modules/aws_reverse_proxy/lambda.tf
+++ b/infra/modules/aws_reverse_proxy/lambda.tf
@@ -1,13 +1,13 @@
 locals {
   config = {
-    hsts_max_age                         = var.hsts_max_age
-    basic_auth_username                  = var.basic_auth_username
-    basic_auth_password                  = var.basic_auth_password
-    basic_auth_realm                     = var.basic_auth_realm
-    basic_auth_body                      = var.basic_auth_body
-    override_response_status             = var.override_response_status
-    override_response_status_description = var.override_response_status_description
-    override_response_body               = var.override_response_body
+    hsts_max_age             = var.hsts_max_age
+    basic_auth_username      = var.basic_auth_username
+    basic_auth_password      = var.basic_auth_password
+    basic_auth_realm         = var.basic_auth_realm
+    basic_auth_body          = var.basic_auth_body
+    override_response_code   = var.override_response_code
+    override_response_status = var.override_response_status
+    override_response_body   = var.override_response_body
   }
 }
 

--- a/infra/modules/aws_reverse_proxy/lambda.tf
+++ b/infra/modules/aws_reverse_proxy/lambda.tf
@@ -39,6 +39,17 @@ data "archive_file" "lambda_zip" {
   }
 }
 
+# This resource doesn't actually do anything (as is (kind of) the case with null_resource's anyway).
+# It merely exists to make Terraform plans more informative: because the Lambda@Edge config is baked
+# into the JS template, normally you would just see the opaque source_code_hash changing in the plan.
+# With this, you'll actually see which config/header is being changed.
+resource "null_resource" "cloudfront_lambda_at_edge" {
+  triggers = merge(
+    local.config,
+    { add_response_headers = jsonencode(var.add_response_headers) }
+  )
+}
+
 resource "aws_lambda_function" "viewer_request" {
   provider = aws.us_east_1 # This alias is needed because ACM is only available in the "us-east-1" region
 

--- a/infra/modules/aws_reverse_proxy/lambda.tf
+++ b/infra/modules/aws_reverse_proxy/lambda.tf
@@ -64,6 +64,21 @@ resource "aws_lambda_function" "viewer_request" {
   tags             = var.tags
 }
 
+resource "aws_lambda_function" "origin_response" {
+  provider = aws.us_east_1 # This alias is needed because ACM is only available in the "us-east-1" region
+
+  filename         = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  function_name    = "${var.name_prefix}-edge-lambda-response"
+  role             = aws_iam_role.this.arn
+  description      = "${var.comment_prefix}${var.site_domain} (response handler)"
+  handler          = "lambda.origin_response"
+  runtime          = "nodejs12.x"
+  publish          = true # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function ARN must reference a specific function version. (The ARN must end with the version number.)
+  tags             = var.tags
+}
+
+# TODO: DELME
 resource "aws_lambda_function" "origin_response_temp" {
   provider = aws.us_east_1 # This alias is needed because ACM is only available in the "us-east-1" region
 

--- a/infra/modules/aws_reverse_proxy/lambda.tf
+++ b/infra/modules/aws_reverse_proxy/lambda.tf
@@ -78,22 +78,6 @@ resource "aws_lambda_function" "origin_response_temp" {
   tags             = var.tags
 }
 
-# TODO: Once the above, new version of this function has been fully rolled out, this old function can be removed.
-# After that, the "-temp" suffix should be removed using the same process.
-resource "aws_lambda_function" "viewer_response" {
-  provider = aws.us_east_1 # This alias is needed because ACM is only available in the "us-east-1" region
-
-  filename         = data.archive_file.lambda_zip.output_path
-  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
-  function_name    = "${var.name_prefix}-edge-lambda-response"
-  role             = aws_iam_role.this.arn
-  description      = "${var.comment_prefix}${var.site_domain} (response handler)"
-  handler          = "lambda.viewer_response"
-  runtime          = "nodejs12.x"
-  publish          = true # because: error creating CloudFront Distribution: InvalidLambdaFunctionAssociation: The function ARN must reference a specific function version. (The ARN must end with the version number.)
-  tags             = var.tags
-}
-
 # Allow Lambda@Edge to invoke our functions
 resource "aws_iam_role" "this" {
   name = var.name_prefix

--- a/infra/modules/aws_reverse_proxy/lambda.tpl.js
+++ b/infra/modules/aws_reverse_proxy/lambda.tpl.js
@@ -61,11 +61,19 @@ exports.origin_response = (event, context, callback) => {
 
   log('aws_reverse_proxy.origin_response.before', response);
 
+  // Add any additional headers:
   response.headers = {
     ...formatHeaders(hstsHeaders),
     ...response.headers,
     ...formatHeaders(addResponseHeaders),
   };
+
+  // Remove headers that have an override value of "" completely:
+  Object.keys(addResponseHeaders).forEach(header => {
+    if (!addResponseHeaders[header]) delete response.headers[header.toLowerCase()];
+  });
+
+  // Override status code if configured:
   response.status = config.override_response_status || response.status;
   response.statusDescription = config.override_response_status_description || response.statusDescription;
 

--- a/infra/modules/aws_reverse_proxy/lambda.tpl.js
+++ b/infra/modules/aws_reverse_proxy/lambda.tpl.js
@@ -19,10 +19,10 @@ exports.viewer_request = (event, context, callback) => {
 
   log('aws_reverse_proxy.viewer_request.before', request);
 
-  if (config.override_response_status && config.override_response_status_description && config.override_response_body) {
+  if (config.override_response_code && config.override_response_status && config.override_response_body) {
     const response = {
-      status: config.override_response_status,
-      statusDescription: config.override_response_status_description,
+      status: config.override_response_code,
+      statusDescription: config.override_response_status,
       body: config.override_response_body,
       headers: {
         ...formatHeaders(hstsHeaders),
@@ -74,8 +74,8 @@ exports.origin_response = (event, context, callback) => {
   });
 
   // Override status code if configured:
-  response.status = config.override_response_status || response.status;
-  response.statusDescription = config.override_response_status_description || response.statusDescription;
+  response.status = config.override_response_code || response.status;
+  response.statusDescription = config.override_response_status || response.statusDescription;
 
   log('aws_reverse_proxy.origin_response.after', response);
 

--- a/infra/modules/aws_reverse_proxy/lambda.tpl.js
+++ b/infra/modules/aws_reverse_proxy/lambda.tpl.js
@@ -56,10 +56,10 @@ exports.viewer_request = (event, context, callback) => {
 };
 
 // Handle outgoing response to the client
-exports.viewer_response = (event, context, callback) => {
+exports.origin_response = (event, context, callback) => {
   const response = event.Records[0].cf.response;
 
-  log('aws_reverse_proxy.viewer_response.before', response);
+  log('aws_reverse_proxy.origin_response.before', response);
 
   response.headers = {
     ...formatHeaders(hstsHeaders),
@@ -69,7 +69,7 @@ exports.viewer_response = (event, context, callback) => {
   response.status = config.override_response_status || response.status;
   response.statusDescription = config.override_response_status_description || response.statusDescription;
 
-  log('aws_reverse_proxy.viewer_response.after', response);
+  log('aws_reverse_proxy.origin_response.after', response);
 
   callback(null, response);
 };

--- a/infra/modules/aws_reverse_proxy/lambda.tpl.js
+++ b/infra/modules/aws_reverse_proxy/lambda.tpl.js
@@ -66,6 +66,8 @@ exports.viewer_response = (event, context, callback) => {
     ...response.headers,
     ...formatHeaders(addResponseHeaders),
   };
+  response.status = config.override_response_status || response.status;
+  response.statusDescription = config.override_response_status_description || response.statusDescription;
 
   log('aws_reverse_proxy.viewer_response.after', response);
 

--- a/infra/modules/aws_reverse_proxy/lambda.tpl.js
+++ b/infra/modules/aws_reverse_proxy/lambda.tpl.js
@@ -73,9 +73,11 @@ exports.origin_response = (event, context, callback) => {
     if (!addResponseHeaders[header]) delete response.headers[header.toLowerCase()];
   });
 
-  // Override status code if configured:
-  response.status = config.override_response_code || response.status;
-  response.statusDescription = config.override_response_status || response.statusDescription;
+  // Override status code (if so configured):
+  if (!config.override_only_on_code || new RegExp(config.override_only_on_code).test(response.status)) {
+    response.status = config.override_response_code || response.status;
+    response.statusDescription = config.override_response_status || response.statusDescription;
+  }
 
   log('aws_reverse_proxy.origin_response.after', response);
 

--- a/infra/modules/aws_reverse_proxy/variables.tf
+++ b/infra/modules/aws_reverse_proxy/variables.tf
@@ -80,6 +80,12 @@ variable "override_response_body" {
   default     = ""
 }
 
+variable "override_only_on_code" {
+  description = "When non-empty, limits when `override_response_*` variables take effect; for example, setting this to `\"404\"` allows you to turn origin 404's into 200's, while still passing a 302 redirect through to the client (JS-style regex allowed)"
+  type        = string
+  default     = ""
+}
+
 variable "basic_auth_username" {
   description = "When non-empty, require this username with HTTP Basic Auth"
   default     = ""

--- a/infra/modules/aws_reverse_proxy/variables.tf
+++ b/infra/modules/aws_reverse_proxy/variables.tf
@@ -66,17 +66,17 @@ variable "origin_custom_port" {
 }
 
 variable "override_response_status" {
-  description = "When this and the other `override_response_*` variables are non-empty, skip sending the request to the origin altogether, and instead respond as instructed here"
+  description = "When non-empty, replace the HTTP status code received from the origin with this; e.g. override a `404` into a `200`"
   default     = ""
 }
 
 variable "override_response_status_description" {
-  description = "Same as `override_response_status`"
+  description = "When non-empty, replace the HTTP status description received from the origin with this; e.g. override a `\"Not Found\"` into a `\"OK\"`"
   default     = ""
 }
 
 variable "override_response_body" {
-  description = "Same as `override_response_status`"
+  description = "When this and ALL other `override_response_*` variables are non-empty, skip sending the request to the origin altogether, and instead respond as instructed here"
   default     = ""
 }
 

--- a/infra/modules/aws_reverse_proxy/variables.tf
+++ b/infra/modules/aws_reverse_proxy/variables.tf
@@ -65,12 +65,12 @@ variable "origin_custom_port" {
   default     = 0
 }
 
-variable "override_response_status" {
+variable "override_response_code" {
   description = "When non-empty, replace the HTTP status code received from the origin with this; e.g. override a `404` into a `200`"
   default     = ""
 }
 
-variable "override_response_status_description" {
+variable "override_response_status" {
   description = "When non-empty, replace the HTTP status description received from the origin with this; e.g. override a `\"Not Found\"` into a `\"OK\"`"
   default     = ""
 }

--- a/infra/modules/main/frontend.tf
+++ b/infra/modules/main/frontend.tf
@@ -79,6 +79,15 @@ module "frontend" {
     X-XSS-Protection          = "1; mode=block"    # stops pages from loading when they detect reflected cross-site scripting (XSS) attacks; besides legacy browsers, superseded by CSP
     Referrer-Policy           = "same-origin"      # a referrer will be sent for same-site origins, but cross-origin requests will send no referrer information
 
+    # Remove some headers which could disclose details about our upstream server
+    # Note that not all headers can be altered by Lambda@Edge: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html#lambda-header-restrictions
+    Server                 = "" # "Server" header can't be removed, but this will reset it to "CloudFront"
+    X-Amz-Error-Code       = ""
+    X-Amz-Error-Message    = ""
+    X-Amz-Error-Detail-Key = ""
+    X-Amz-Request-Id       = ""
+    X-Amz-Id-2             = ""
+
     # Add CSP header:
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
     Content-Security-Policy = replace(replace(replace(<<-EOT

--- a/infra/modules/main/frontend.tf
+++ b/infra/modules/main/frontend.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket" "frontend_code" {
   # Note, though, that when accessing the bucket over its SSL endpoint, the index_document will not be used
   website {
     index_document = "index.html"
-    error_document = "error.html"
+    error_document = "index.html" # for any URL that isn't a static file, route the request to the index file, so it can try to handle it with client-side routing
   }
 
   logging {
@@ -70,6 +70,8 @@ module "frontend" {
   viewer_https_only          = true
   basic_auth_username        = var.frontend_password == "" ? "" : "symptomradar"
   basic_auth_password        = var.frontend_password
+  override_response_code     = 200
+  override_response_status   = "OK"
 
   add_response_headers = {
 

--- a/infra/modules/main/frontend.tf
+++ b/infra/modules/main/frontend.tf
@@ -72,6 +72,7 @@ module "frontend" {
   basic_auth_password        = var.frontend_password
   override_response_code     = 200
   override_response_status   = "OK"
+  override_only_on_code      = "404"
 
   add_response_headers = {
 

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -20,3 +20,7 @@ provider "archive" {
 provider "template" {
   version = "~> 2.1"
 }
+
+provider "null" {
+  version = "~> 2.1"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "symptomradar",
-  "homepage": ".",
   "engines": {
     "npm": ">=6 <7",
     "node": ">=12 <13"

--- a/public/index-embed-v1.html
+++ b/public/index-embed-v1.html
@@ -10,7 +10,12 @@
     <noscript>{{ no_js }}</noscript>
     <main>
       <div class="container">
-        <img id="logo" class="logo" src="./oiretutka-logo-gradient.svg" alt="Oiretutka. Helsingin Sanomat ja Futurice." />
+        <img
+          id="logo"
+          class="logo"
+          src="%PUBLIC_URL%/oiretutka-logo-gradient.svg"
+          alt="Oiretutka. Helsingin Sanomat ja Futurice."
+        />
         <div id="form-info" class="form-info">
           <h1 id="page-title" tabindex="-1">
             {{ page_title }}

--- a/scripts/deploy-frontend
+++ b/scripts/deploy-frontend
@@ -16,7 +16,7 @@ DEFAULT_LANG="fi"
 
 # Build the frontend static files
 (
-  INLINE_RUNTIME_CHUNK=false GENERATE_SOURCEMAP=false npm run "$2" # don't inline webpack runtime (inline scripts are categorically banned by our CSP)
+  PUBLIC_URL="$3" INLINE_RUNTIME_CHUNK=false GENERATE_SOURCEMAP=false npm run "$2" # don't inline webpack runtime (inline scripts are categorically banned by our CSP)
   (cd "$BUILD_DIR" && rm -fv index-*.html *manifest* service-worker.js) # remove some cruft we don't need
   npm run ts-node "$SELF_DIR/../scripts/translate-frontend.ts"
   (cd "$BUILD_DIR" && [ ! -f index.$DEFAULT_LANG.html ] || mv -v index{.$DEFAULT_LANG,}.html) # if translated index files got generated, replace the templated index HTML with the default-lang one


### PR DESCRIPTION
tl;dr:

* When requesting a resource that's handled by client-side routing, it won't exist on S3, which will respond with 404, and serve `/index.html` as the error document. Our Lambda@Edge function will now map it to a 200.
* In the same go, masked some headers from upstream we may not want to disclose. Not really for security, but for looking professional. :smirk: 
* Added a `null_resource.cloudfront_lambda_at_edge` that makes Terraform diffs related to the Lambda@Edge changes easier to grok.
* Updated the build process to refer to assets by absolute path, so that if the client-side routing pretends the path is `/foo/bar/baz/`, `index.css` is still fetched from `/index.css`, not `/foo/bar/baz/index.css`.

Closes #171