### PR TITLE
Add embed version of map

### DIFF
--- a/src/frontend/main/App.tsx
+++ b/src/frontend/main/App.tsx
@@ -98,6 +98,7 @@ export const App = () => (
     <main>
       <Router>
         <MapView path="/" />
+        <MapView path="/map-embed" />
         <About path="about" />
         <Privacy path="tietosuojalauseke" />
         <Survey path="survey" />

--- a/src/frontend/main/Header.tsx
+++ b/src/frontend/main/Header.tsx
@@ -103,30 +103,35 @@ const LinkItem = ({ to, linkText, icon }: LinkProps) => {
 };
 
 const Header = ({ location }: HeaderProps) => {
-  return (
-    <AppHeader>
-      <HeaderContainer isFullWidthView={location === '/' ? true : false}>
-        <div>
-          <LogoImage src={Logo} alt="Oiretutka. Helsingin Sanomat ja Futurice." />
-        </div>
-        <Nav>
-          <LinkContainer>
-            <LinkItem
-              to="/"
-              linkText="Kartta"
-              icon={(match: { uri: string; path: string } | null) => <MapIcon fillColor={match ? '#000' : '#0047FF'} />}
-            />
-            <LinkItem
-              to="survey"
-              linkText="Kyselylomake"
-              icon={match => <SurveyIcon fillColor={match ? '#000' : '#0047FF'} />}
-            />
-            <LinkItem to="about" linkText="Info" icon={match => <AboutIcon fillColor={match ? '#000' : '#0047FF'} />} />
-          </LinkContainer>
-        </Nav>
-      </HeaderContainer>
-    </AppHeader>
-  );
+  const isEmbedView = location === '/map-embed';
+  if (!isEmbedView) {
+    return (
+      <AppHeader>
+        <HeaderContainer isFullWidthView={location === '/' ? true : false}>
+          <div>
+            <LogoImage src={Logo} alt="Oiretutka. Helsingin Sanomat ja Futurice." />
+          </div>
+          <Nav>
+            <LinkContainer>
+              <LinkItem to="/" linkText="Kartta" icon={match => <MapIcon fillColor={match ? '#000' : '#0047FF'} />} />
+              <LinkItem
+                to="survey"
+                linkText="Kyselylomake"
+                icon={match => <SurveyIcon fillColor={match ? '#000' : '#0047FF'} />}
+              />
+              <LinkItem
+                to="about"
+                linkText="Info"
+                icon={match => <AboutIcon fillColor={match ? '#000' : '#0047FF'} />}
+              />
+            </LinkContainer>
+          </Nav>
+        </HeaderContainer>
+      </AppHeader>
+    );
+  } else {
+    return null;
+  }
 };
 
 export default Header;

--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -147,10 +147,13 @@ const CloseButton = styled.button`
 `;
 
 const MapView = (props: RouteComponentProps) => {
+  const currentPath = props.location!.pathname;
+  const isEmbed = currentPath === '/map-embed';
+  const topPartHeight = isEmbed ? 80 : 225;
   const { isShowing, toggleModal } = useModal();
   const [showMapInfo, setShowMapInfo] = useState(true);
   const [selectedFilter, setSelectedFilter] = useState('corona_suspicion_yes');
-  const [mapHeight, setMapHeight] = useState(window.innerHeight - 225);
+  const [mapHeight, setMapHeight] = useState(window.innerHeight - topPartHeight);
   const [mapWidth, setMapWidth] = useState(window.innerWidth - 25);
   const [activeCityData, setActiveCityData] = useState({});
 


### PR DESCRIPTION
The path `/map-embed` will render the map without the header component. When embedded, the iframe height should be defined (no resizer needed) and the map will adjust to that. For example:
`<Iframe src="/map-embed" height="600" />`
