### PR TITLE
Abuse detection system

### DIFF
--- a/infra/modules/main/abuse_detection.tf
+++ b/infra/modules/main/abuse_detection.tf
@@ -1,0 +1,17 @@
+# This table is used as a key/value store by the abuse detection subsystem
+resource "aws_dynamodb_table" "abuse_detection" {
+  name         = "${var.name_prefix}-abuse-detection"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "ADKey"
+  tags         = local.tags_backend
+
+  attribute {
+    name = "ADKey"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ADTtl"
+    enabled        = true
+  }
+}

--- a/infra/modules/main/backend.tf
+++ b/infra/modules/main/backend.tf
@@ -81,6 +81,15 @@ resource "aws_iam_policy" "backend_api" {
         "ssm:GetParameters"
       ],
       "Resource": "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_secrets_prefix}secret-pepper"
+    },
+    {
+      "Sid": "ReadWriteAccessToAbuseDetectionTable",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:BatchGetItem",
+        "dynamodb:UpdateItem"
+      ],
+      "Resource": "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.abuse_detection.name}"
     }
   ]
 }

--- a/infra/modules/main/backend.tf
+++ b/infra/modules/main/backend.tf
@@ -20,6 +20,7 @@ locals {
     DOMAIN_NAME_OPEN_DATA      = var.open_data_domain
     KNOWN_HASHING_PEPPER       = var.known_hashing_pepper
     SSM_SECRETS_PREFIX         = var.ssm_secrets_prefix
+    ABUSE_DETECTION_TABLE      = aws_dynamodb_table.abuse_detection.name
   }
 }
 

--- a/infra/modules/main/storage.tf
+++ b/infra/modules/main/storage.tf
@@ -121,3 +121,21 @@ resource "aws_athena_named_query" "returning_participants" {
     ;
   SQL
 }
+
+# Example: Interacting with JSON
+# Based on https://docs.aws.amazon.com/athena/latest/ug/extracting-data-from-JSON.html
+/*
+WITH dataset AS (
+  SELECT
+    '{"name": "Susan Smith",
+      "org": "engineering",
+      "project": {"name":"project1", "completed":false}}' AS blob
+)
+SELECT
+  json_extract(blob, '$.name') AS name,
+  json_extract(blob, '$.project.name') AS project
+FROM
+  dataset
+WHERE
+  json_extract_scalar(blob, '$.project.name') = 'project1'
+*/

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "backend-build": "npm run lint-node && rm -rf build && tsc --project tsconfig-backend.json",
     "\n==================== UTILS ====================": "",
     "set-frontend": "/bin/bash -c 'set -x; (cd src/ && ln -fs index-frontend-$1.ts* index.tsx); (cd public/ && ln -fs index-$1.html index.html)' --",
-    "ts-node": "NODE_PATH=src ts-node --compiler-options '{\"module\":\"commonjs\"}'"
+    "ts-node": "NODE_PATH=src ts-node --project tsconfig-backend.json --files"
   },
   "dependencies": {
     "@reach/dialog": "^0.10.0",

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -38,13 +38,20 @@ const headers = {
 };
 
 describe('performAbuseDetection()', () => {
-  it('works', () => {
+  it('works for the first request', () => {
+    const dynamoDb = createMockDynamoDbClient();
     return performAbuseDetection(
-      sourceIp,
-      headers,
-      Promise.resolve('fake-secret-pepper'),
+      dynamoDb,
+      {
+        source_ip: sourceIp,
+        user_agent: headers['User-Agent'],
+        forwarded_for: normalizeForwardedFor(headers['X-Forwarded-For']),
+      },
       () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
-    ).then(res => expect(res).toEqual({ seen_ip_24h: 0, seen_ua_24h: 0, seen_ff_24h: 0 }));
+      3,
+    ).then(res => {
+      expect(res).toEqual({ source_ip: 0, user_agent: 0, forwarded_for: 0 });
+    });
   });
 });
 

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -78,7 +78,7 @@ describe('performAbuseDetection()', () => {
             expect(score).toEqual({
               source_ip: 0,
               user_agent: 0,
-              forwarded_for: 0,
+              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
             }),
           )
           .then(
@@ -101,7 +101,7 @@ describe('performAbuseDetection()', () => {
             expect(score).toEqual({
               source_ip: 2,
               user_agent: 2,
-              forwarded_for: 0,
+              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
             }),
           )
           .then(
@@ -126,7 +126,7 @@ describe('performAbuseDetection()', () => {
             expect(score).toEqual({
               source_ip: 2,
               user_agent: 4, // all requests have had the same UA, even if they had a different IP
-              forwarded_for: 0,
+              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
             }),
           )
           .then(
@@ -150,7 +150,7 @@ describe('performAbuseDetection()', () => {
             expect(score).toEqual({
               source_ip: 2,
               user_agent: 2,
-              forwarded_for: 0,
+              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
             }),
           )
           .then(
@@ -180,7 +180,7 @@ describe('performAbuseDetection()', () => {
             expect(score).toEqual({
               source_ip: 2,
               user_agent: 2,
-              forwarded_for: 0,
+              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
             }),
           )
           .then(
@@ -216,7 +216,7 @@ describe('performAbuseDetection()', () => {
             expect(score).toEqual({
               source_ip: 1, // only once from this distinct IP
               user_agent: 2, // but twice with this UA
-              forwarded_for: 0,
+              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
             }),
           )
           .then(

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -1,5 +1,5 @@
-import { performAbuseDetection, createDynamoDbClient, getStorageKey, getTimeRange } from './abuseDetection';
 import { first, last } from 'lodash';
+import { DynamoDBClient, getStorageKey, getTimeRange, performAbuseDetection } from './abuseDetection';
 
 // Available as event.requestContext.identity.sourceIp in the Lambda request handler
 const sourceIp = '87.92.62.179';
@@ -82,7 +82,7 @@ describe('getTimeRange()', () => {
   });
 });
 
-export function createMockDynamoDbClient(): ReturnType<typeof createDynamoDbClient> {
+export function createMockDynamoDbClient(): DynamoDBClient {
   const storage: { [key: string]: number | undefined } = {};
   return {
     incrementKey(key: string) {

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -82,7 +82,7 @@ describe('getTimeRange()', () => {
   });
 });
 
-export function createMockDynamoDbClient(): DynamoDBClient {
+export function createMockDynamoDbClient(): DynamoDBClient & { _storage: { [key: string]: number | undefined } } {
   const storage: { [key: string]: number | undefined } = {};
   return {
     incrementKey(key: string) {
@@ -91,5 +91,6 @@ export function createMockDynamoDbClient(): DynamoDBClient {
     getValues(keys: string[]) {
       return Promise.resolve(keys.map(key => storage[key] || 0));
     },
+    _storage: storage,
   };
 }

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -1,0 +1,42 @@
+import { performAbuseDetection } from './abuseDetection';
+
+// Available as event.requestContext.identity.sourceIp in the Lambda request handler
+const sourceIp = '87.92.62.179';
+
+// Available as event.headers in the Lambda request handler
+const headers = {
+  Accept:
+    'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+  'Accept-Encoding': 'gzip, deflate, br',
+  'Accept-Language': 'en-US,en;q=0.9,fi;q=0.8',
+  'CloudFront-Forwarded-Proto': 'https',
+  'CloudFront-Is-Desktop-Viewer': 'true',
+  'CloudFront-Is-Mobile-Viewer': 'false',
+  'CloudFront-Is-SmartTV-Viewer': 'false',
+  'CloudFront-Is-Tablet-Viewer': 'false',
+  'CloudFront-Viewer-Country': 'FI',
+  Host: 'api.dev.oiretutka.fi',
+  'sec-fetch-mode': 'navigate',
+  'sec-fetch-site': 'none',
+  'sec-fetch-user': '?1',
+  'upgrade-insecure-requests': '1',
+  'User-Agent':
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36',
+  Via: '2.0 7ddb2b9bba2e00f11b5de58d7aa1249c.cloudfront.net (CloudFront)',
+  'X-Amz-Cf-Id': 'W06KV_M9t3WpFFvbR8Uy65yG5IKoNivgEa2Mvj4hespoqRIuXIdAOA==',
+  'X-Amzn-Trace-Id': 'Root=1-5e8f1ea1-57f325cca78ac88b553f9d7d',
+  'X-Forwarded-For': '87.92.62.179, 52.46.36.85',
+  'X-Forwarded-Port': '443',
+  'X-Forwarded-Proto': 'https',
+};
+
+describe('performAbuseDetection()', () => {
+  it('works', () => {
+    return performAbuseDetection(
+      sourceIp,
+      headers,
+      Promise.resolve('fake-secret-pepper'),
+      () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
+    ).then(res => expect(res).toEqual({ seen_ip_24h: 0, seen_ua_24h: 0, seen_ff_24h: 0 }));
+  });
+});

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeForwardedFor,
   performAbuseDetection,
 } from './abuseDetection';
+import { hash } from './main';
 
 // Available as event.requestContext.identity.sourceIp in the Lambda request handler
 const sourceIp = '87.92.62.179';
@@ -38,245 +39,267 @@ const headers = {
 };
 
 describe('performAbuseDetection()', () => {
-  function request(dynamoDb: DynamoDBClient, fingerprint: AbuseFingerprint, time = 0) {
-    const { readPromise, writePromise } = performAbuseDetection(
-      dynamoDb,
-      fingerprint,
-      identity, // by default, don't hash anything in the test suite
-      () => 1585649303678 + time, // i.e. "2020-03-31T10:08:23.678Z"
-      3, // only operate on 3 hours' range for the test suite
-    );
-    return Promise.all([readPromise, writePromise]).then(([readResult]) => readResult);
-  }
+  [false, true].forEach(withHashing =>
+    describe(`with${withHashing ? '' : 'out'} hashing`, () => {
+      // This suite is repeated for both configurations, to check it works the same
 
-  const sampleReq1 = {
-    source_ip: sourceIp,
-    user_agent: headers['User-Agent'],
-    forwarded_for: normalizeForwardedFor(headers['X-Forwarded-For']),
-  };
+      function request(dynamoDb: DynamoDBClient, fingerprint: AbuseFingerprint, time = 0) {
+        const { readPromise, writePromise } = performAbuseDetection(
+          dynamoDb,
+          fingerprint,
+          withHashing ? x => hash(x, 'fake-secret-pepper') : identity,
+          () => 1585649303678 + time, // i.e. "2020-03-31T10:08:23.678Z"
+          3, // only operate on 3 hours' range for the test suite
+        );
+        return Promise.all([readPromise, writePromise]).then(([readResult]) => readResult);
+      }
 
-  const sampleReq2 = {
-    ...sampleReq1,
-    source_ip: '123.123.123.123',
-  };
+      const sampleReq1 = {
+        source_ip: sourceIp,
+        user_agent: headers['User-Agent'],
+        forwarded_for: normalizeForwardedFor(headers['X-Forwarded-For']),
+      };
 
-  const sampleReq3 = {
-    ...sampleReq1,
-    forwarded_for: normalizeForwardedFor('50.50.50.50, 12.12.12.12, 87.92.62.179, 52.46.36.172'),
-  };
+      const sampleReq2 = {
+        ...sampleReq1,
+        source_ip: '123.123.123.123',
+      };
 
-  it('works for the first request', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    return Promise.resolve()
-      .then(() => request(dynamoDb, sampleReq1))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 0,
-          user_agent: 0,
-          forwarded_for: 0,
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-        }),
-      );
-  });
+      const sampleReq3 = {
+        ...sampleReq1,
+        forwarded_for: normalizeForwardedFor('50.50.50.50, 12.12.12.12, 87.92.62.179, 52.46.36.172'),
+      };
 
-  it('works for subsequent requests', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    return Promise.resolve()
-      .then(() => request(dynamoDb, sampleReq1))
-      .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS))
-      .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 2,
-          user_agent: 2,
-          forwarded_for: 0,
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/source_ip/87.92.62.179': 3,
-          '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
-        }),
-      );
-  });
+      it('works for the first request', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        return Promise.resolve()
+          .then(() => request(dynamoDb, sampleReq1))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 0,
+              user_agent: 0,
+              forwarded_for: 0,
+            }),
+          )
+          .then(
+            () =>
+              withHashing || // only assert storage contents when they're legible
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+              }),
+          );
+      });
 
-  it('works for mixed requests', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    return Promise.resolve()
-      .then(() => request(dynamoDb, sampleReq1))
-      .then(() => request(dynamoDb, sampleReq2))
-      .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS))
-      .then(() => request(dynamoDb, sampleReq2, MINUTE_IN_MS * 2))
-      .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 2,
-          user_agent: 4, // all requests have had the same UA, even if they had a different IP
-          forwarded_for: 0,
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/source_ip/87.92.62.179': 3,
-          '2020-03-31T10Z/source_ip/123.123.123.123': 2,
-          '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 5,
-        }),
-      );
-  });
+      it('works for subsequent requests', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        return Promise.resolve()
+          .then(() => request(dynamoDb, sampleReq1))
+          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS))
+          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 2,
+              user_agent: 2,
+              forwarded_for: 0,
+            }),
+          )
+          .then(
+            () =>
+              withHashing ||
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/source_ip/87.92.62.179': 3,
+                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
+              }),
+          );
+      });
 
-  it('works for requests spread over multiple hours', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    return Promise.resolve()
-      .then(() => request(dynamoDb, sampleReq1))
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS))
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 2,
-          user_agent: 2,
-          forwarded_for: 0,
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T11Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T12Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-        }),
-      );
-  });
+      it('works for mixed requests', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        return Promise.resolve()
+          .then(() => request(dynamoDb, sampleReq1))
+          .then(() => request(dynamoDb, sampleReq2))
+          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS))
+          .then(() => request(dynamoDb, sampleReq2, MINUTE_IN_MS * 2))
+          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 2,
+              user_agent: 4, // all requests have had the same UA, even if they had a different IP
+              forwarded_for: 0,
+            }),
+          )
+          .then(
+            () =>
+              withHashing ||
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/source_ip/87.92.62.179': 3,
+                '2020-03-31T10Z/source_ip/123.123.123.123': 2,
+                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 5,
+              }),
+          );
+      });
 
-  it('works for requests going over the time range', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    return Promise.resolve()
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 0)) // by the time we expect(), this will be too told to be counted!
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 1)) // ^ ditto
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2)) // ^ ditto
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 3))
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 4))
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 5))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 2,
-          user_agent: 2,
-          forwarded_for: 0,
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T11Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T12Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T13Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T14Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T15Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-        }),
-      );
-  });
+      it('works for requests spread over multiple hours', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        return Promise.resolve()
+          .then(() => request(dynamoDb, sampleReq1))
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS))
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 2,
+              user_agent: 2,
+              forwarded_for: 0,
+            }),
+          )
+          .then(
+            () =>
+              withHashing ||
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T11Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T12Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+              }),
+          );
+      });
 
-  it('works for mixed requests going over the time range', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    return Promise.resolve()
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 0)) // by the time we expect(), this will be too told to be counted!
-      .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 1)) // ^ ditto
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2)) // ^ ditto
-      .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 3))
-      .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 4))
-      .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 5))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 1, // only once from this distinct IP
-          user_agent: 2, // but twice with this UA
-          forwarded_for: 0,
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T11Z/source_ip/123.123.123.123': 1,
-          '2020-03-31T12Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T13Z/source_ip/123.123.123.123': 1,
-          '2020-03-31T14Z/source_ip/87.92.62.179': 1,
-          '2020-03-31T15Z/source_ip/123.123.123.123': 1,
-          '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-          '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-        }),
-      );
-  });
+      it('works for requests going over the time range', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        return Promise.resolve()
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 0)) // by the time we expect(), this will be too told to be counted!
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 1)) // ^ ditto
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2)) // ^ ditto
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 3))
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 4))
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 5))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 2,
+              user_agent: 2,
+              forwarded_for: 0,
+            }),
+          )
+          .then(
+            () =>
+              withHashing ||
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T11Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T12Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T13Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T14Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T15Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+              }),
+          );
+      });
 
-  it('works for requests with X-Forwarded-For', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    return Promise.resolve()
-      .then(() => request(dynamoDb, sampleReq3))
-      .then(() => request(dynamoDb, sampleReq3, MINUTE_IN_MS * 1))
-      .then(() => request(dynamoDb, sampleReq3, MINUTE_IN_MS * 2))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 2,
-          user_agent: 2,
-          forwarded_for: 2,
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/source_ip/87.92.62.179': 3,
-          '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
-          '2020-03-31T10Z/forwarded_for/50.50.50.50, 12.12.12.12': 3,
-        }),
-      );
-  });
+      it('works for mixed requests going over the time range', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        return Promise.resolve()
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 0)) // by the time we expect(), this will be too told to be counted!
+          .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 1)) // ^ ditto
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2)) // ^ ditto
+          .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 3))
+          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 4))
+          .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 5))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 1, // only once from this distinct IP
+              user_agent: 2, // but twice with this UA
+              forwarded_for: 0,
+            }),
+          )
+          .then(
+            () =>
+              withHashing ||
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T11Z/source_ip/123.123.123.123': 1,
+                '2020-03-31T12Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T13Z/source_ip/123.123.123.123': 1,
+                '2020-03-31T14Z/source_ip/87.92.62.179': 1,
+                '2020-03-31T15Z/source_ip/123.123.123.123': 1,
+                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+                '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+              }),
+          );
+      });
 
-  it('works for requests with varying X-Forwarded-For', () => {
-    const dynamoDb = createMockDynamoDbClient();
-    const clientBehindProxy = (ip: string) => ({
-      ...sampleReq3,
-      forwarded_for: normalizeForwardedFor(`${ip}, 87.92.62.179, 52.46.36.172`),
-      user_agent: `FakeBrowser/${ip}`,
-    });
-    return Promise.resolve()
-      .then(() => request(dynamoDb, clientBehindProxy('1.1.1.1'), MINUTE_IN_MS * 0))
-      .then(() => request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 1))
-      .then(() => request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 2))
-      .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 3))
-      .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 4))
-      .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 5))
-      .then(score =>
-        expect(score).toEqual({
-          source_ip: 5, // all requests came from the same "real" IP
-          user_agent: 2, // last 3 had the same UA
-          forwarded_for: 2, // and the same FF
-        }),
-      )
-      .then(() =>
-        expect(dynamoDb._storage).toEqual({
-          '2020-03-31T10Z/forwarded_for/1.1.1.1': 1,
-          '2020-03-31T10Z/forwarded_for/2.2.2.2': 2,
-          '2020-03-31T10Z/forwarded_for/3.3.3.3': 3,
-          '2020-03-31T10Z/source_ip/87.92.62.179': 6,
-          '2020-03-31T10Z/user_agent/FakeBrowser/1.1.1.1': 1,
-          '2020-03-31T10Z/user_agent/FakeBrowser/2.2.2.2': 2,
-          '2020-03-31T10Z/user_agent/FakeBrowser/3.3.3.3': 3,
-        }),
-      );
-  });
+      it('works for requests with X-Forwarded-For', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        return Promise.resolve()
+          .then(() => request(dynamoDb, sampleReq3))
+          .then(() => request(dynamoDb, sampleReq3, MINUTE_IN_MS * 1))
+          .then(() => request(dynamoDb, sampleReq3, MINUTE_IN_MS * 2))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 2,
+              user_agent: 2,
+              forwarded_for: 2,
+            }),
+          )
+          .then(
+            () =>
+              withHashing ||
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/source_ip/87.92.62.179': 3,
+                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
+                '2020-03-31T10Z/forwarded_for/50.50.50.50, 12.12.12.12': 3,
+              }),
+          );
+      });
+
+      it('works for requests with varying X-Forwarded-For', () => {
+        const dynamoDb = createMockDynamoDbClient();
+        const clientBehindProxy = (ip: string) => ({
+          ...sampleReq3,
+          forwarded_for: normalizeForwardedFor(`${ip}, 87.92.62.179, 52.46.36.172`),
+          user_agent: `FakeBrowser/${ip}`,
+        });
+        return Promise.resolve()
+          .then(() => request(dynamoDb, clientBehindProxy('1.1.1.1'), MINUTE_IN_MS * 0))
+          .then(() => request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 1))
+          .then(() => request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 2))
+          .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 3))
+          .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 4))
+          .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 5))
+          .then(score =>
+            expect(score).toEqual({
+              source_ip: 5, // all requests came from the same "real" IP
+              user_agent: 2, // last 3 had the same UA
+              forwarded_for: 2, // and the same FF
+            }),
+          )
+          .then(
+            () =>
+              withHashing ||
+              expect(dynamoDb._storage).toEqual({
+                '2020-03-31T10Z/forwarded_for/1.1.1.1': 1,
+                '2020-03-31T10Z/forwarded_for/2.2.2.2': 2,
+                '2020-03-31T10Z/forwarded_for/3.3.3.3': 3,
+                '2020-03-31T10Z/source_ip/87.92.62.179': 6,
+                '2020-03-31T10Z/user_agent/FakeBrowser/1.1.1.1': 1,
+                '2020-03-31T10Z/user_agent/FakeBrowser/2.2.2.2': 2,
+                '2020-03-31T10Z/user_agent/FakeBrowser/3.3.3.3': 3,
+              }),
+          );
+      });
+    }),
+  );
 });
 
 describe('createMockDynamoDbClient()', () => {

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -1,4 +1,4 @@
-import { performAbuseDetection, createDynamoDbClient } from './abuseDetection';
+import { performAbuseDetection, createDynamoDbClient, getStorageKey } from './abuseDetection';
 
 // Available as event.requestContext.identity.sourceIp in the Lambda request handler
 const sourceIp = '87.92.62.179';
@@ -54,6 +54,18 @@ describe('createMockDynamoDbClient()', () => {
     return Promise.all(['key-01', 'key-01', 'key-03', 'key-04'].map(client.incrementKey))
       .then(() => client.getValues(['key-01', 'key-02', 'key-03', 'key-04']))
       .then(res => expect(res).toEqual([2, 0, 1, 1]));
+  });
+});
+
+describe('getStorageKey()', () => {
+  it('works', () => {
+    expect(
+      getStorageKey(
+        'source-ip',
+        '87.92.62.179',
+        1586857707869, // 2020-04-14T09:48:27.869Z
+      ),
+    ).toEqual('2020-04-14T09Z/source-ip/87.92.62.179');
   });
 });
 

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -1,4 +1,4 @@
-import { first, last } from 'lodash';
+import { first, identity, last } from 'lodash';
 import { HOUR_IN_MS, MINUTE_IN_MS } from '../common/time';
 import {
   AbuseFingerprint,
@@ -42,6 +42,7 @@ describe('performAbuseDetection()', () => {
     const { readPromise, writePromise } = performAbuseDetection(
       dynamoDb,
       fingerprint,
+      identity, // by default, don't hash anything in the test suite
       () => 1585649303678 + time, // i.e. "2020-03-31T10:08:23.678Z"
       3, // only operate on 3 hours' range for the test suite
     );

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -1,4 +1,5 @@
-import { performAbuseDetection, createDynamoDbClient, getStorageKey } from './abuseDetection';
+import { performAbuseDetection, createDynamoDbClient, getStorageKey, getTimeRange } from './abuseDetection';
+import { first, last } from 'lodash';
 
 // Available as event.requestContext.identity.sourceIp in the Lambda request handler
 const sourceIp = '87.92.62.179';
@@ -66,6 +67,18 @@ describe('getStorageKey()', () => {
         1586857707869, // 2020-04-14T09:48:27.869Z
       ),
     ).toEqual('2020-04-14T09Z/source-ip/87.92.62.179');
+  });
+});
+
+describe('getTimeRange()', () => {
+  it('has the correct number of items', () => {
+    expect(getTimeRange(1586857707869).length).toEqual(24);
+  });
+
+  it('has the correct start and end timestamps', () => {
+    const range = getTimeRange(1586857707869).map(ts => new Date(ts).toISOString());
+    expect(first(range)).toEqual('2020-04-13T10:48:27.869Z');
+    expect(last(range)).toEqual('2020-04-14T09:48:27.869Z');
   });
 });
 

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -1,5 +1,11 @@
 import { first, last } from 'lodash';
-import { DynamoDBClient, getStorageKey, getTimeRange, performAbuseDetection } from './abuseDetection';
+import {
+  DynamoDBClient,
+  getStorageKey,
+  getTimeRange,
+  normalizeForwardedFor,
+  performAbuseDetection,
+} from './abuseDetection';
 
 // Available as event.requestContext.identity.sourceIp in the Lambda request handler
 const sourceIp = '87.92.62.179';
@@ -79,6 +85,22 @@ describe('getTimeRange()', () => {
     const range = getTimeRange(1586857707869).map(ts => new Date(ts).toISOString());
     expect(first(range)).toEqual('2020-04-13T10:48:27.869Z');
     expect(last(range)).toEqual('2020-04-14T09:48:27.869Z');
+  });
+});
+
+describe('normalizeForwardedFor()', () => {
+  it('works when omitted', () => {
+    expect(normalizeForwardedFor()).toEqual('');
+  });
+
+  it('works without additional proxies', () => {
+    expect(normalizeForwardedFor('87.92.62.179, 52.46.36.85')).toEqual('');
+  });
+
+  it('works with additional proxies', () => {
+    expect(normalizeForwardedFor('50.50.50.50, 12.12.12.12, 87.92.62.179, 52.46.36.172')).toEqual(
+      '50.50.50.50, 12.12.12.12',
+    );
   });
 });
 

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -1,5 +1,5 @@
 import * as AWS from 'aws-sdk';
-import { range } from 'lodash';
+import { dropRight, flatMap, range } from 'lodash';
 
 const TIME_RANGE_HOURS = 24;
 const HOUR_IN_MS = 60 * 60 * 1000;
@@ -96,4 +96,12 @@ export function getTimeRange(
   timeRangeHours = TIME_RANGE_HOURS,
 ) {
   return range(ts - (timeRangeHours - 1) * HOUR_IN_MS, ts + 1, HOUR_IN_MS);
+}
+
+// Drops the last 2 items in a standard-formatted 'X-Forwarded-For' header; in our use case, those are:
+// 1) The "real" IP of the client, which we get via other means
+// 2) The CloudFront edge node via which the request was routed
+// What we're instead interested in is whether there's something IN ADDITION to those in this header
+export function normalizeForwardedFor(value?: string) {
+  return dropRight((value || '').split(', '), 2).join(', ');
 }

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -1,3 +1,5 @@
+import * as AWS from 'aws-sdk';
+
 type AbuseScore = {
   seen_ip_24h: number;
   seen_ua_24h: number;
@@ -18,4 +20,60 @@ export function performAbuseDetection(
     seen_ua_24h: 0,
     seen_ff_24h: 0,
   });
+}
+
+// Creates a specialized DynamoDB API wrapper for reading/writing abuse detection related data
+export function createDynamoDbClient(tableName: string, ttlSeconds: number) {
+  var ddb = new AWS.DynamoDB({ apiVersion: '2012-08-10' }); // note: for local development, you may need to: AWS.config.update({ region: 'eu-west-1' });
+  return {
+    // Increments the integer value at given key.
+    // If the key doesn't exist, it's created automatically as having value 0, then incremented normally.
+    // Returns the integer value (after being incremented).
+    incrementKey(key: string): Promise<number> {
+      return ddb
+        .updateItem({
+          TableName: tableName,
+          Key: { ADKey: { S: key } },
+          UpdateExpression: 'SET ADVal = if_not_exists(ADVal, :init) + :inc, ADTtl = :ttl',
+          ExpressionAttributeValues: {
+            ':inc': { N: '1' },
+            ':init': { N: '0' },
+            ':ttl': { N: Math.round((Date.now() + 1000 * ttlSeconds) / 1000) + '' },
+          },
+          ReturnValues: 'UPDATED_NEW',
+        })
+        .promise()
+        .then(res => res?.Attributes?.ADVal)
+        .then(unwrapNumber);
+    },
+
+    // Returns the integer values at given keys.
+    // If some keys don't contain values, they're treated as 0's.
+    getValues(keys: string[]): Promise<number[]> {
+      return ddb
+        .batchGetItem({
+          RequestItems: {
+            [tableName]: {
+              AttributesToGet: ['ADKey', 'ADVal'],
+              Keys: keys.map(key => ({ ADKey: { S: key } })),
+            },
+          },
+        })
+        .promise()
+        .then(res =>
+          (res?.Responses?.[tableName] || []).reduce(
+            (memo, next) => ({ ...memo, [next.ADKey.S || '']: unwrapNumber(next.ADVal) }),
+            {} as { [key: string]: number },
+          ),
+        )
+        .then(res => keys.map(key => res[key] || 0));
+    },
+  };
+}
+
+// See interface AttributeValue in DynamoDB
+function unwrapNumber(attrValue?: { N?: string }): number {
+  const num = parseInt(attrValue?.N || '', 10);
+  if (Number.isFinite(num)) return num;
+  throw new Error(`Unexpected number value from DynamoDB: "${attrValue?.N}"`);
 }

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -1,4 +1,8 @@
 import * as AWS from 'aws-sdk';
+import { range } from 'lodash';
+
+const TIME_RANGE_HOURS = 24;
+const HOUR_IN_MS = 60 * 60 * 1000;
 
 type AbuseScore = {
   seen_ip_24h: number;
@@ -82,4 +86,13 @@ function unwrapNumber(attrValue?: { N?: string }): number {
 export function getStorageKey(propertyName: string, propertyValue: string, ts: number) {
   const hour = new Date(ts).toISOString().replace(/:.*Z/, 'Z'); // to preserve privacy, intentionally reduce precision of the timestamp
   return `${hour}/${propertyName}/${propertyValue}`;
+}
+
+// Returns the timestamps, 1 hour apart, that cover the whole time range over which we perform abuse detection
+export function getTimeRange(
+  ts: number,
+  // Allow overriding defaults in test code:
+  timeRangeHours = TIME_RANGE_HOURS,
+) {
+  return range(ts - (timeRangeHours - 1) * HOUR_IN_MS, ts + 1, HOUR_IN_MS);
 }

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -5,12 +5,12 @@ import { nonNullable } from '../common/types';
 
 const TIME_RANGE_HOURS = 24;
 
-type AbuseFingerprint = {
+export type AbuseFingerprint = {
   source_ip: string;
   user_agent: string;
   forwarded_for: string;
 };
-type AbuseScore = {
+export type AbuseScore = {
   [key in keyof AbuseFingerprint]: number;
 };
 

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -51,7 +51,10 @@ export function performAbuseDetection(
 }
 
 // Creates a specialized DynamoDB API wrapper for reading/writing abuse detection related data
-export function createDynamoDbClient(tableName: string, ttlSeconds: number) {
+export function createDynamoDbClient(
+  tableName: string,
+  ttlSeconds = TIME_RANGE_HOURS * 60 * 60, // by default, expire each key 24 h after its last write
+) {
   var ddb = new AWS.DynamoDB({ apiVersion: '2012-08-10' }); // note: for local development, you may need to: AWS.config.update({ region: 'eu-west-1' });
   return {
     // Increments the integer value at given key.

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -74,6 +74,7 @@ export function createDynamoDbClient(tableName: string, ttlSeconds: number) {
     },
   };
 }
+export type DynamoDBClient = ReturnType<typeof createDynamoDbClient>;
 
 // See interface AttributeValue in DynamoDB
 function unwrapNumber(attrValue?: { N?: string }): number {

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -1,0 +1,21 @@
+type AbuseScore = {
+  seen_ip_24h: number;
+  seen_ua_24h: number;
+  seen_ff_24h: number;
+};
+
+type Headers = { [name: string]: string };
+
+export function performAbuseDetection(
+  sourceIp: string,
+  headers: Headers,
+  secretPepper: Promise<string>,
+  // Allow overriding non-deterministic parts in test code:
+  timestamp = Date.now,
+): Promise<AbuseScore> {
+  return Promise.resolve({
+    seen_ip_24h: 0,
+    seen_ua_24h: 0,
+    seen_ff_24h: 0,
+  });
+}

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -77,3 +77,9 @@ function unwrapNumber(attrValue?: { N?: string }): number {
   if (Number.isFinite(num)) return num;
   throw new Error(`Unexpected number value from DynamoDB: "${attrValue?.N}"`);
 }
+
+// Returns the key under which this key/value pair should be tracked in DynamoDB
+export function getStorageKey(propertyName: string, propertyValue: string, ts: number) {
+  const hour = new Date(ts).toISOString().replace(/:.*Z/, 'Z'); // to preserve privacy, intentionally reduce precision of the timestamp
+  return `${hour}/${propertyName}/${propertyValue}`;
+}

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -17,6 +17,9 @@ export type AbuseScore = {
 const emptyScore: AbuseScore = { source_ip: 0, user_agent: 0, forwarded_for: 0 };
 const fingerprintKeys = (Object.keys(emptyScore) as any) as Array<keyof AbuseFingerprint>;
 
+// This special score can be used to indicate that a given response couldn't be scored, due to e.g. DynamoDB error or some such
+export const ABUSE_SCORE_ERROR: AbuseScore = { source_ip: -2, user_agent: -2, forwarded_for: -2 };
+
 // Reads & updates DynamoDB to keep track of our abuse detection metrics.
 // Promises the "abuse score" for the given fingerprint (i.e. request).
 // The read/write Promises are returned separately, so that client requests can be serviced immediately after reading the current abuse score finishes.

--- a/src/backend/abuseDetection.ts
+++ b/src/backend/abuseDetection.ts
@@ -1,9 +1,9 @@
 import * as AWS from 'aws-sdk';
 import { dropRight, flatMap, range } from 'lodash';
+import { HOUR_IN_MS } from '../common/time';
 import { nonNullable } from '../common/types';
 
 const TIME_RANGE_HOURS = 24;
-const HOUR_IN_MS = 60 * 60 * 1000;
 
 type AbuseFingerprint = {
   source_ip: string;

--- a/src/backend/main.test.ts
+++ b/src/backend/main.test.ts
@@ -1,6 +1,7 @@
-import { FrontendResponseModelT, BackendResponseModelT } from '../common/model';
-import { prepareResponseForStorage, getStorageKey } from './main';
+import { BackendResponseModelT, FrontendResponseModelT } from '../common/model';
+import { normalizeForwardedFor } from './abuseDetection';
 import { createMockDynamoDbClient } from './abuseDetection.test';
+import { getStorageKey, prepareResponseForStorage } from './main';
 
 const cannedUuid = '5fa8764a-7337-11ea-96ca-d38ac3d1909b';
 const incomingResponseSample: FrontendResponseModelT = {
@@ -49,7 +50,7 @@ const persistedResponseSample: BackendResponseModelT = {
   stomach_issues: 'no',
   timestamp: '2020-03-31T10:08:00.000Z', // note the rounding to minute precision
   abuse_score: {
-    forwarded_for: 0,
+    forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
     source_ip: 0,
     user_agent: 0,
   },
@@ -64,7 +65,7 @@ describe('prepareResponseForStorage()', () => {
       {
         source_ip: '1.1.1.1',
         user_agent: 'Mozilla/5.0...Safari/537.36',
-        forwarded_for: '',
+        forwarded_for: normalizeForwardedFor('1.1.1.1, 52.46.36.85'),
       },
       Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,
@@ -85,7 +86,7 @@ describe('prepareResponseForStorage()', () => {
       {
         source_ip: '1.1.1.1',
         user_agent: 'Mozilla/5.0...Safari/537.36',
-        forwarded_for: '',
+        forwarded_for: normalizeForwardedFor('1.1.1.1, 52.46.36.85'),
       },
       Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,
@@ -111,7 +112,7 @@ describe('prepareResponseForStorage()', () => {
       {
         source_ip: '1.1.1.1',
         user_agent: 'Mozilla/5.0...Safari/537.36',
-        forwarded_for: '',
+        forwarded_for: normalizeForwardedFor('1.1.1.1, 52.46.36.85'),
       },
       Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,

--- a/src/backend/main.test.ts
+++ b/src/backend/main.test.ts
@@ -97,6 +97,36 @@ describe('prepareResponseForStorage()', () => {
       }),
     );
   });
+
+  it('handles errors', () => {
+    return prepareResponseForStorage(
+      incomingResponseSample,
+      'FI',
+      {
+        ...createMockDynamoDbClient(),
+        getValues() {
+          return Promise.reject(new Error('Simulated error in test suite'));
+        },
+      },
+      {
+        source_ip: '1.1.1.1',
+        user_agent: 'Mozilla/5.0...Safari/537.36',
+        forwarded_for: '',
+      },
+      Promise.resolve('fake-secret-pepper'),
+      () => cannedUuid,
+      () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
+    ).then(r =>
+      expect(r).toEqual({
+        ...persistedResponseSample,
+        abuse_score: {
+          forwarded_for: -2,
+          source_ip: -2,
+          user_agent: -2,
+        },
+      }),
+    );
+  });
 });
 
 describe('getStorageKey()', () => {

--- a/src/backend/main.test.ts
+++ b/src/backend/main.test.ts
@@ -1,5 +1,6 @@
 import { FrontendResponseModelT, BackendResponseModelT } from '../common/model';
 import { prepareResponseForStorage, getStorageKey } from './main';
+import { createMockDynamoDbClient } from './abuseDetection.test';
 
 const cannedUuid = '5fa8764a-7337-11ea-96ca-d38ac3d1909b';
 const incomingResponseSample: FrontendResponseModelT = {
@@ -54,6 +55,12 @@ describe('prepareResponseForStorage()', () => {
     return prepareResponseForStorage(
       incomingResponseSample,
       'FI',
+      createMockDynamoDbClient(),
+      {
+        source_ip: '1.1.1.1',
+        user_agent: 'Mozilla/5.0...Safari/537.36',
+        forwarded_for: '',
+      },
       Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,
       () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -23,7 +23,7 @@ const athenaExpress = new AthenaExpress({ aws: AWS, s3: `s3://${athenaResultsBuc
 let cachedSecretPepper: undefined | Promise<string>;
 
 // Saves the given response into our storage bucket
-export function storeResponseInS3(response: FrontendResponseModelT, countryCode: string) {
+export function storeResponse(response: FrontendResponseModelT, countryCode: string) {
   return Promise.resolve()
     .then(() =>
       prepareResponseForStorage(

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -1,8 +1,9 @@
-import * as AWS from 'aws-sdk';
 import AthenaExpress from 'athena-express';
+import * as AWS from 'aws-sdk';
 import { createHash } from 'crypto';
 import { v4 as uuidV4 } from 'uuid';
 import { assertIs, BackendResponseModel, BackendResponseModelT, FrontendResponseModelT } from '../common/model';
+import { AbuseFingerprint, DynamoDBClient, performAbuseDetection } from './abuseDetection';
 import { mapPostalCode } from './postalCode';
 import { getSecret } from './secrets';
 import { totalResponsesQuery, postalCodeLevelDataQuery } from './queries';
@@ -23,12 +24,19 @@ const athenaExpress = new AthenaExpress({ aws: AWS, s3: `s3://${athenaResultsBuc
 let cachedSecretPepper: undefined | Promise<string>;
 
 // Saves the given response into our storage bucket
-export function storeResponse(response: FrontendResponseModelT, countryCode: string) {
+export function storeResponse(
+  response: FrontendResponseModelT,
+  countryCode: string,
+  dynamoDb: DynamoDBClient,
+  fingerprint: AbuseFingerprint,
+) {
   return Promise.resolve()
     .then(() =>
       prepareResponseForStorage(
         response,
         countryCode,
+        dynamoDb,
+        fingerprint,
         (cachedSecretPepper = cachedSecretPepper || getSecret('secret-pepper')),
       ),
     )
@@ -50,26 +58,31 @@ export function storeResponse(response: FrontendResponseModelT, countryCode: str
 export function prepareResponseForStorage(
   response: FrontendResponseModelT,
   countryCode: string,
+  dynamoDb: DynamoDBClient,
+  fingerprint: AbuseFingerprint,
   secretPepper: Promise<string>,
   // Allow overriding non-deterministic parts in test code:
   uuid: () => string = uuidV4,
   timestamp = Date.now,
 ): Promise<BackendResponseModelT> {
-  return Promise.resolve(secretPepper).then(secretPepper => {
-    const meta = {
-      response_id: uuid(),
-      participant_id: hash(hash(response.participant_id, knownPepper), secretPepper), // to preserve privacy, hash the participant_id before storing it, so after opening up the dataset, malicious actors can't submit more responses that pretend to belong to a previous participant
-      timestamp: new Date(timestamp()) // for security, don't trust browser clock, as it may be wrong or fraudulent
-        .toISOString()
-        .replace(/:..\..*/, ':00.000Z'), // to preserve privacy, intentionally reduce precision of the timestamp
-      app_version: 'v2.2', // TODO: This should be set by the deploy process, not hard-coded!
-      country_code: countryCode,
-      postal_code: mapPostalCode(response).postal_code, // to protect the privacy of participants from very small postal code areas, they are merged into larger ones, based on known population data
-      duration: response.duration === null ? null : parseInt(response.duration),
-    };
-    const model: BackendResponseModelT = { ...meta, ...response, ...meta }; // the double "...meta" is just for vanity: we want the meta-fields to appear first in the JSON representation
-    return assertIs(BackendResponseModel)(model); // ensure we still pass runtime validations as well
-  });
+  return Promise.resolve(secretPepper).then(secretPepper =>
+    performAbuseDetection(dynamoDb, fingerprint, val => hash(val, secretPepper)).readPromise.then(abuseScore => {
+      console.log('Abuse score', { abuseScore });
+      const meta = {
+        response_id: uuid(),
+        participant_id: hash(hash(response.participant_id, knownPepper), secretPepper), // to preserve privacy, hash the participant_id before storing it, so after opening up the dataset, malicious actors can't submit more responses that pretend to belong to a previous participant
+        timestamp: new Date(timestamp()) // for security, don't trust browser clock, as it may be wrong or fraudulent
+          .toISOString()
+          .replace(/:..\..*/, ':00.000Z'), // to preserve privacy, intentionally reduce precision of the timestamp
+        app_version: 'v2.2', // TODO: This should be set by the deploy process, not hard-coded!
+        country_code: countryCode,
+        postal_code: mapPostalCode(response).postal_code, // to protect the privacy of participants from very small postal code areas, they are merged into larger ones, based on known population data
+        duration: response.duration === null ? null : parseInt(response.duration),
+      };
+      const model: BackendResponseModelT = { ...meta, ...response, ...meta }; // the double "...meta" is just for vanity: we want the meta-fields to appear first in the JSON representation
+      return assertIs(BackendResponseModel)(model); // ensure we still pass runtime validations as well
+    }),
+  );
 }
 
 // Produces the key under which this response should be stored in S3

--- a/src/backend/main.ts
+++ b/src/backend/main.ts
@@ -79,7 +79,7 @@ export function getStorageKey(response: BackendResponseModelT): string {
 }
 
 // @example hash("whatever", "secret") => "K/FwCDUHL3iVb9JAMBdSEurw4rWuO/iJmcIWCn2B++s="
-function hash(input: string, pepper: string) {
+export function hash(input: string, pepper: string) {
   if (!pepper) throw new Error(`No pepper provided for hashing; while possible, this is likely a configuration error`);
   return createHash('sha256')
     .update(input + pepper)

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -1,6 +1,7 @@
 import { isRight } from 'fp-ts/lib/Either';
 import * as t from 'io-ts';
 import { PathReporter } from 'io-ts/lib/PathReporter';
+import { AbuseScore } from '../backend/abuseDetection';
 import {
   age,
   cough,
@@ -48,6 +49,13 @@ export const FrontendResponseModel = t.strict(
 );
 export type FrontendResponseModelT = t.TypeOf<typeof FrontendResponseModel>;
 
+// Define this sub-object separately so we can check it against the AbuseScore type
+const abuse_score: { [key in keyof AbuseScore]: t.NumberC } = {
+  source_ip: t.number,
+  user_agent: t.number,
+  forwarded_for: t.number,
+};
+
 export const BackendResponseModel = t.strict(
   {
     response_id: t.string,
@@ -57,6 +65,7 @@ export const BackendResponseModel = t.strict(
     country_code: t.string,
     ...responseFields,
     duration: t.union([t.number, t.null]), // for persistence, let's cast to number
+    abuse_score: t.strict(abuse_score),
   },
   'BackendResponseModel',
 );

--- a/src/common/time.ts
+++ b/src/common/time.ts
@@ -1,0 +1,3 @@
+export const MINUTE_IN_MS = 60 * 1000;
+export const HOUR_IN_MS = 60 * MINUTE_IN_MS;
+export const DAY_IN_MS = 24 * HOUR_IN_MS;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,0 +1,6 @@
+// Helper for excluding null & undefined.
+// @example const arr: Array<string | null> = [];
+//          const strings: Array<string> = arr.filter(isNotNull);
+export function nonNullable<T extends any>(x: T): x is NonNullable<T> {
+  return x !== null && typeof x !== 'undefined';
+}

--- a/src/index-backend.ts
+++ b/src/index-backend.ts
@@ -1,7 +1,10 @@
 import { APIGatewayProxyHandler, Handler } from 'aws-lambda';
 import { v4 as uuidV4 } from 'uuid';
+import { createDynamoDbClient, normalizeForwardedFor } from './backend/abuseDetection';
 import { prepareResponseForStorage, storeDataDumpsToS3, storeResponse } from './backend/main';
 import { assertIs, FrontendResponseModel, FrontendResponseModelT } from './common/model';
+
+const dynamoDb = createDynamoDbClient(process.env.ABUSE_DETECTION_TABLE || '');
 
 export const apiEntrypoint: APIGatewayProxyHandler = (event, context) => {
   console.log(`Incoming request: ${event.httpMethod} ${event.path}`); // to preserve privacy, don't log any headers, etc
@@ -12,7 +15,13 @@ export const apiEntrypoint: APIGatewayProxyHandler = (event, context) => {
     return Promise.resolve()
       .then(() => JSON.parse(event.body || '') as unknown)
       .then(assertIs(FrontendResponseModel))
-      .then(res => storeResponse(res, countryCode))
+      .then(res =>
+        storeResponse(res, countryCode, dynamoDb, {
+          source_ip: event.requestContext.identity.sourceIp,
+          user_agent: event.headers['User-Agent'],
+          forwarded_for: normalizeForwardedFor(event.headers['X-Forwarded-For']),
+        }),
+      )
       .then(() => response(200, { success: true }))
       .catch(err => response(500, { error: true }, err));
   }
@@ -53,7 +62,19 @@ if (process.argv[0].match(/\/ts-node$/)) {
   };
   Promise.resolve(test)
     .then(assertIs(FrontendResponseModel))
-    .then(res => prepareResponseForStorage(res, 'FI', Promise.resolve('fake-secret-pepper')))
+    .then(res =>
+      prepareResponseForStorage(
+        res,
+        'FI',
+        dynamoDb,
+        {
+          source_ip: '127.0.0.1',
+          user_agent: 'localhost',
+          forwarded_for: '',
+        },
+        Promise.resolve('fake-secret-pepper'),
+      ),
+    )
     .catch(err => err)
     .then(res => console.log(res));
 }

--- a/src/index-backend.ts
+++ b/src/index-backend.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyHandler, Handler } from 'aws-lambda';
 import { v4 as uuidV4 } from 'uuid';
+import { prepareResponseForStorage, storeDataDumpsToS3, storeResponse } from './backend/main';
 import { assertIs, FrontendResponseModel, FrontendResponseModelT } from './common/model';
-import { storeResponseInS3, prepareResponseForStorage, storeDataDumpsToS3 } from './backend/main';
 
 export const apiEntrypoint: APIGatewayProxyHandler = (event, context) => {
   console.log(`Incoming request: ${event.httpMethod} ${event.path}`); // to preserve privacy, don't log any headers, etc
@@ -12,7 +12,7 @@ export const apiEntrypoint: APIGatewayProxyHandler = (event, context) => {
     return Promise.resolve()
       .then(() => JSON.parse(event.body || '') as unknown)
       .then(assertIs(FrontendResponseModel))
-      .then(res => storeResponseInS3(res, countryCode))
+      .then(res => storeResponse(res, countryCode))
       .then(() => response(200, { success: true }))
       .catch(err => response(500, { error: true }, err));
   }


### PR DESCRIPTION
This has been waiting on the backlog for a long time.

tl;dr:

* When a request comes in, we grab its source IP, its `User-Agent` and `X-Forwarded-For`, and call that its "fingerprint"
* Immediately after, we put those values through a one-way hash function, with a secret pepper included, so it can't be reversed
* For each such hashed fingerprint key/value pair, we upsert an item in DynamoDB, e.g. `"2020-03-31T10Z/source_ip/6NehvvOtv6bGjk7FTtutfcozHqX478AVLV1EbcpmV+g=" => 3`
* This means this IP has been seen 3 times within the hour-long time bucket at `2020-03-31T10:xx:yy`
* Each key has a TTL value set up in DynamoDB, so they expire 24 hours after last being written (so the DB doesn't balloon forever)
* We then calculate an "abuse score" for the incoming request, by simply tallying these values over the past 24 hours; e.g. `{ source_ip: 2, user_agent: 5, forwarded_for: -1 }` means we've seen this same IP 2 times during the past 24 hours, the `User-Agent` 5 times, and the `-1` is a special value meaning we didn't get an `X-Forwarded-For` value for this request (so it's pointless to score how common it's recently been)
* This abuse score is stored along with the response
* Later, this score can be used to assess the credibility of each response, during the data dump generation phase

Closes #27