### PR TITLE
Convert promise chains to async functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7847,6 +7847,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -9417,6 +9418,11 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -14265,6 +14271,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {
@@ -15047,6 +15054,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "aws-sdk": "^2.642.0",
     "check-node-version": "^4.0.2",
     "concurrently": "^5.1.0",
+    "nan": "2.14.1",
     "prettier": "^1.19.1",
     "ts-node": "^8.8.1",
     "typescript": "^3.8.3"

--- a/src/backend/abuseDetection.test.ts
+++ b/src/backend/abuseDetection.test.ts
@@ -43,7 +43,7 @@ describe('performAbuseDetection()', () => {
     describe(`with${withHashing ? '' : 'out'} hashing`, () => {
       // This suite is repeated for both configurations, to check it works the same
 
-      function request(dynamoDb: DynamoDBClient, fingerprint: AbuseFingerprint, time = 0) {
+      async function request(dynamoDb: DynamoDBClient, fingerprint: AbuseFingerprint, time = 0) {
         const { readPromise, writePromise } = performAbuseDetection(
           dynamoDb,
           fingerprint,
@@ -51,7 +51,9 @@ describe('performAbuseDetection()', () => {
           () => 1585649303678 + time, // i.e. "2020-03-31T10:08:23.678Z"
           3, // only operate on 3 hours' range for the test suite
         );
-        return Promise.all([readPromise, writePromise]).then(([readResult]) => readResult);
+
+        const [readResult] = await Promise.all([readPromise, writePromise]);
+        return readResult;
       }
 
       const sampleReq1 = {
@@ -70,233 +72,185 @@ describe('performAbuseDetection()', () => {
         forwarded_for: normalizeForwardedFor('50.50.50.50, 12.12.12.12, 87.92.62.179, 52.46.36.172'),
       };
 
-      it('works for the first request', () => {
+      it('works for the first request', async () => {
         const dynamoDb = createMockDynamoDbClient();
-        return Promise.resolve()
-          .then(() => request(dynamoDb, sampleReq1))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 0,
-              user_agent: 0,
-              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
-            }),
-          )
-          .then(
-            () =>
-              withHashing || // only assert storage contents when they're legible
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-              }),
-          );
+        const score = await request(dynamoDb, sampleReq1);
+        expect(score).toEqual({
+          source_ip: 0,
+          user_agent: 0,
+          forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
+        });
+        withHashing || // only assert storage contents when they're legible
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+          });
       });
 
-      it('works for subsequent requests', () => {
+      it('works for subsequent requests', async () => {
         const dynamoDb = createMockDynamoDbClient();
-        return Promise.resolve()
-          .then(() => request(dynamoDb, sampleReq1))
-          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS))
-          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 2,
-              user_agent: 2,
-              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
-            }),
-          )
-          .then(
-            () =>
-              withHashing ||
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/source_ip/87.92.62.179': 3,
-                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
-              }),
-          );
+        await request(dynamoDb, sampleReq1);
+        await request(dynamoDb, sampleReq1, MINUTE_IN_MS);
+        const score = await request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10);
+        expect(score).toEqual({
+          source_ip: 2,
+          user_agent: 2,
+          forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
+        });
+        withHashing ||
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/source_ip/87.92.62.179': 3,
+            '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
+          });
       });
 
-      it('works for mixed requests', () => {
+      it('works for mixed requests', async () => {
         const dynamoDb = createMockDynamoDbClient();
-        return Promise.resolve()
-          .then(() => request(dynamoDb, sampleReq1))
-          .then(() => request(dynamoDb, sampleReq2))
-          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS))
-          .then(() => request(dynamoDb, sampleReq2, MINUTE_IN_MS * 2))
-          .then(() => request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 2,
-              user_agent: 4, // all requests have had the same UA, even if they had a different IP
-              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
-            }),
-          )
-          .then(
-            () =>
-              withHashing ||
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/source_ip/87.92.62.179': 3,
-                '2020-03-31T10Z/source_ip/123.123.123.123': 2,
-                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 5,
-              }),
-          );
+        await request(dynamoDb, sampleReq1);
+        await request(dynamoDb, sampleReq2);
+        await request(dynamoDb, sampleReq1, MINUTE_IN_MS);
+        await request(dynamoDb, sampleReq2, MINUTE_IN_MS * 2);
+        const score = await request(dynamoDb, sampleReq1, MINUTE_IN_MS * 10);
+        expect(score).toEqual({
+          source_ip: 2,
+          user_agent: 4, // all requests have had the same UA, even if they had a different IP
+          forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
+        });
+        withHashing ||
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/source_ip/87.92.62.179': 3,
+            '2020-03-31T10Z/source_ip/123.123.123.123': 2,
+            '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 5,
+          });
       });
 
-      it('works for requests spread over multiple hours', () => {
+      it('works for requests spread over multiple hours', async () => {
         const dynamoDb = createMockDynamoDbClient();
-        return Promise.resolve()
-          .then(() => request(dynamoDb, sampleReq1))
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS))
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 2,
-              user_agent: 2,
-              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
-            }),
-          )
-          .then(
-            () =>
-              withHashing ||
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T11Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T12Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-              }),
-          );
+        await request(dynamoDb, sampleReq1);
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS);
+        const score = await request(dynamoDb, sampleReq1, HOUR_IN_MS * 2);
+        expect(score).toEqual({
+          source_ip: 2,
+          user_agent: 2,
+          forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
+        });
+        withHashing ||
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T11Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T12Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+          });
       });
 
-      it('works for requests going over the time range', () => {
+      it('works for requests going over the time range', async () => {
         const dynamoDb = createMockDynamoDbClient();
-        return Promise.resolve()
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 0)) // by the time we expect(), this will be too told to be counted!
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 1)) // ^ ditto
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2)) // ^ ditto
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 3))
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 4))
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 5))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 2,
-              user_agent: 2,
-              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
-            }),
-          )
-          .then(
-            () =>
-              withHashing ||
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T11Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T12Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T13Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T14Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T15Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-              }),
-          );
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 0); // by the time we expect(), this will be too told to be counted!
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 1); // ^ ditto
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 2); // ^ ditto
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 3);
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 4);
+        const score = await request(dynamoDb, sampleReq1, HOUR_IN_MS * 5);
+        expect(score).toEqual({
+          source_ip: 2,
+          user_agent: 2,
+          forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
+        });
+        withHashing ||
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T11Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T12Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T13Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T14Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T15Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+          });
       });
 
-      it('works for mixed requests going over the time range', () => {
+      it('works for mixed requests going over the time range', async () => {
         const dynamoDb = createMockDynamoDbClient();
-        return Promise.resolve()
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 0)) // by the time we expect(), this will be too told to be counted!
-          .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 1)) // ^ ditto
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 2)) // ^ ditto
-          .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 3))
-          .then(() => request(dynamoDb, sampleReq1, HOUR_IN_MS * 4))
-          .then(() => request(dynamoDb, sampleReq2, HOUR_IN_MS * 5))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 1, // only once from this distinct IP
-              user_agent: 2, // but twice with this UA
-              forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
-            }),
-          )
-          .then(
-            () =>
-              withHashing ||
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T11Z/source_ip/123.123.123.123': 1,
-                '2020-03-31T12Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T13Z/source_ip/123.123.123.123': 1,
-                '2020-03-31T14Z/source_ip/87.92.62.179': 1,
-                '2020-03-31T15Z/source_ip/123.123.123.123': 1,
-                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-                '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
-              }),
-          );
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 0); // by the time we expect(), this will be too told to be counted!
+        await request(dynamoDb, sampleReq2, HOUR_IN_MS * 1); // ^ ditto
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 2); // ^ ditto
+        await request(dynamoDb, sampleReq2, HOUR_IN_MS * 3);
+        await request(dynamoDb, sampleReq1, HOUR_IN_MS * 4);
+        const score = await request(dynamoDb, sampleReq2, HOUR_IN_MS * 5);
+        expect(score).toEqual({
+          source_ip: 1, // only once from this distinct IP
+          user_agent: 2, // but twice with this UA
+          forwarded_for: -1, // i.e. ABUSE_SCORE_MISSING, because we didn't provide a "X-Forwarded-For" value to score
+        });
+        withHashing ||
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T11Z/source_ip/123.123.123.123': 1,
+            '2020-03-31T12Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T13Z/source_ip/123.123.123.123': 1,
+            '2020-03-31T14Z/source_ip/87.92.62.179': 1,
+            '2020-03-31T15Z/source_ip/123.123.123.123': 1,
+            '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T11Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T12Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T13Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T14Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+            '2020-03-31T15Z/user_agent/Mozilla/5.0...Safari/537.36': 1,
+          });
       });
 
-      it('works for requests with X-Forwarded-For', () => {
+      it('works for requests with X-Forwarded-For', async () => {
         const dynamoDb = createMockDynamoDbClient();
-        return Promise.resolve()
-          .then(() => request(dynamoDb, sampleReq3))
-          .then(() => request(dynamoDb, sampleReq3, MINUTE_IN_MS * 1))
-          .then(() => request(dynamoDb, sampleReq3, MINUTE_IN_MS * 2))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 2,
-              user_agent: 2,
-              forwarded_for: 2,
-            }),
-          )
-          .then(
-            () =>
-              withHashing ||
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/source_ip/87.92.62.179': 3,
-                '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
-                '2020-03-31T10Z/forwarded_for/50.50.50.50, 12.12.12.12': 3,
-              }),
-          );
+        await request(dynamoDb, sampleReq3);
+        await request(dynamoDb, sampleReq3, MINUTE_IN_MS * 1);
+        const score = await request(dynamoDb, sampleReq3, MINUTE_IN_MS * 2);
+        expect(score).toEqual({
+          source_ip: 2,
+          user_agent: 2,
+          forwarded_for: 2,
+        });
+        withHashing ||
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/source_ip/87.92.62.179': 3,
+            '2020-03-31T10Z/user_agent/Mozilla/5.0...Safari/537.36': 3,
+            '2020-03-31T10Z/forwarded_for/50.50.50.50, 12.12.12.12': 3,
+          });
       });
 
-      it('works for requests with varying X-Forwarded-For', () => {
+      it('works for requests with varying X-Forwarded-For', async () => {
         const dynamoDb = createMockDynamoDbClient();
         const clientBehindProxy = (ip: string) => ({
           ...sampleReq3,
           forwarded_for: normalizeForwardedFor(`${ip}, 87.92.62.179, 52.46.36.172`),
           user_agent: `FakeBrowser/${ip}`,
         });
-        return Promise.resolve()
-          .then(() => request(dynamoDb, clientBehindProxy('1.1.1.1'), MINUTE_IN_MS * 0))
-          .then(() => request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 1))
-          .then(() => request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 2))
-          .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 3))
-          .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 4))
-          .then(() => request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 5))
-          .then(score =>
-            expect(score).toEqual({
-              source_ip: 5, // all requests came from the same "real" IP
-              user_agent: 2, // last 3 had the same UA
-              forwarded_for: 2, // and the same FF
-            }),
-          )
-          .then(
-            () =>
-              withHashing ||
-              expect(dynamoDb._storage).toEqual({
-                '2020-03-31T10Z/forwarded_for/1.1.1.1': 1,
-                '2020-03-31T10Z/forwarded_for/2.2.2.2': 2,
-                '2020-03-31T10Z/forwarded_for/3.3.3.3': 3,
-                '2020-03-31T10Z/source_ip/87.92.62.179': 6,
-                '2020-03-31T10Z/user_agent/FakeBrowser/1.1.1.1': 1,
-                '2020-03-31T10Z/user_agent/FakeBrowser/2.2.2.2': 2,
-                '2020-03-31T10Z/user_agent/FakeBrowser/3.3.3.3': 3,
-              }),
-          );
+        await request(dynamoDb, clientBehindProxy('1.1.1.1'), MINUTE_IN_MS * 0);
+        await request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 1);
+        await request(dynamoDb, clientBehindProxy('2.2.2.2'), MINUTE_IN_MS * 2);
+        await request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 3);
+        await request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 4);
+        const score = await request(dynamoDb, clientBehindProxy('3.3.3.3'), MINUTE_IN_MS * 5);
+        expect(score).toEqual({
+          source_ip: 5, // all requests came from the same "real" IP
+          user_agent: 2, // last 3 had the same UA
+          forwarded_for: 2, // and the same FF
+        });
+        withHashing ||
+          expect(dynamoDb._storage).toEqual({
+            '2020-03-31T10Z/forwarded_for/1.1.1.1': 1,
+            '2020-03-31T10Z/forwarded_for/2.2.2.2': 2,
+            '2020-03-31T10Z/forwarded_for/3.3.3.3': 3,
+            '2020-03-31T10Z/source_ip/87.92.62.179': 6,
+            '2020-03-31T10Z/user_agent/FakeBrowser/1.1.1.1': 1,
+            '2020-03-31T10Z/user_agent/FakeBrowser/2.2.2.2': 2,
+            '2020-03-31T10Z/user_agent/FakeBrowser/3.3.3.3': 3,
+          });
       });
     }),
   );

--- a/src/backend/main.test.ts
+++ b/src/backend/main.test.ts
@@ -57,8 +57,8 @@ const persistedResponseSample: BackendResponseModelT = {
 };
 
 describe('prepareResponseForStorage()', () => {
-  it('works for the first request', () => {
-    return prepareResponseForStorage(
+  it('works for the first request', async () => {
+    const r = await prepareResponseForStorage(
       incomingResponseSample,
       'FI',
       createMockDynamoDbClient(),
@@ -70,11 +70,12 @@ describe('prepareResponseForStorage()', () => {
       Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,
       () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
-    ).then(r => expect(r).toEqual(persistedResponseSample));
+    );
+    expect(r).toEqual(persistedResponseSample);
   });
 
-  it('works for a second request', () => {
-    return prepareResponseForStorage(
+  it('works for a second request', async () => {
+    const r = await prepareResponseForStorage(
       incomingResponseSample,
       'FI',
       {
@@ -91,16 +92,15 @@ describe('prepareResponseForStorage()', () => {
       Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,
       () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
-    ).then(r =>
-      expect(r).toEqual({
-        ...persistedResponseSample,
-        abuse_score: { ...persistedResponseSample.abuse_score, source_ip: 123 },
-      }),
     );
+    expect(r).toEqual({
+      ...persistedResponseSample,
+      abuse_score: { ...persistedResponseSample.abuse_score, source_ip: 123 },
+    });
   });
 
-  it('handles errors', () => {
-    return prepareResponseForStorage(
+  it('handles errors', async () => {
+    const r = await prepareResponseForStorage(
       incomingResponseSample,
       'FI',
       {
@@ -117,16 +117,15 @@ describe('prepareResponseForStorage()', () => {
       Promise.resolve('fake-secret-pepper'),
       () => cannedUuid,
       () => 1585649303678, // i.e. "2020-03-31T10:08:23.678Z"
-    ).then(r =>
-      expect(r).toEqual({
-        ...persistedResponseSample,
-        abuse_score: {
-          forwarded_for: -2,
-          source_ip: -2,
-          user_agent: -2,
-        },
-      }),
     );
+    expect(r).toEqual({
+      ...persistedResponseSample,
+      abuse_score: {
+        forwarded_for: -2,
+        source_ip: -2,
+        user_agent: -2,
+      },
+    });
   });
 });
 

--- a/src/backend/secrets.ts
+++ b/src/backend/secrets.ts
@@ -3,15 +3,18 @@ import * as AWS from 'aws-sdk';
 const ssm = new AWS.SSM(); // note: for local development, you may need to: AWS.config.update({ region: 'eu-west-1' });
 
 // Fetches a correctly prefixed secret value from AWS Systems Manager Parameter Store (SSM)
-export function getSecret(name: 'secret-pepper') {
+export async function getSecret(name: 'secret-pepper') {
   const fullName = process.env.SSM_SECRETS_PREFIX + name;
   console.log(`Getting secret "${fullName}"`);
-  return ssm
-    .getParameters({
-      Names: [fullName],
-      WithDecryption: true,
-    })
-    .promise()
-    .then(data => (data.Parameters || [])[0].Value || '')
-    .catch(err => Promise.reject(new Error(`Couldn't get secret "${fullName}" (caused by\n${err}\n)`)));
+  try {
+    const data = await ssm
+      .getParameters({
+        Names: [fullName],
+        WithDecryption: true,
+      })
+      .promise();
+    return (data.Parameters || [])[0].Value || '';
+  } catch (err) {
+    throw new Error(`Couldn't get secret "${fullName}" (caused by\n${err}\n)`);
+  }
 }


### PR DESCRIPTION
Alternative to https://github.com/futurice/symptomradar/pull/260

~~Touched `index-backend.ts` and `backend/main.ts`. Left tests and `abuseDetection.ts` in peace.~~

All promise chains in backend code should now be converted to `async` functions (apart from few instances where promise chains are more straightforward, such as https://github.com/futurice/symptomradar/blob/master/src/backend/abuseDetection.test.ts#L308)