### PR TITLE
City level data view

### DIFF
--- a/src/frontend/main/App.tsx
+++ b/src/frontend/main/App.tsx
@@ -124,8 +124,8 @@ export const App = () => {
         <Menu menuOpen={menuOpen} setMenuOpen={setMenuOpen}></Menu>
         <main>
           <Router>
-            {<MapView path="/" responseData={data} />}
-            {<MapView path="/map-embed" responseData={data} />}
+            <MapView path="/" responseData={data} />
+            <MapView path="/map-embed" responseData={data} />
             <About path="about" />
             <Privacy path="tietosuojalauseke" />
             <Survey path="survey" />

--- a/src/frontend/main/App.tsx
+++ b/src/frontend/main/App.tsx
@@ -22,6 +22,7 @@ import Roboto700Woff2 from './assets/fonts/roboto-v20-latin-ext_latin-700.woff2'
 
 const theme = {
   grey: '#757575',
+  lightGrey: '#ECECEC',
   white: '#FFFFFF',
   black: '#000000',
   blue: '#0047FF',

--- a/src/frontend/main/Header.tsx
+++ b/src/frontend/main/Header.tsx
@@ -14,7 +14,7 @@ type HeaderProps = {
 const AppHeader = styled.header`
   padding: 16px 16px 10px 16px;
   background-color: ${props => props.theme.white};
-  border-bottom: 1px solid ${props => props.theme.black};
+  border-bottom: 1px solid ${props => props.theme.grey};
   height: ${HEADERHEIGHT}px;
 `;
 

--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -180,7 +180,7 @@ const MapView = (props: MapViewProps) => {
   const [selectedFilter, setSelectedFilter] = useState<FilterKey>(FILTERS.corona_suspicion_yes.id as FilterKey);
   const [mapHeight, setMapHeight] = useState(window.innerHeight - topPartHeight - 10);
   const data = props.responseData.data;
-  const [activeView, setActiveView] = useState<'MAP' | 'TABLE'>('TABLE');
+  const [activeView, setActiveView] = useState<'MAP' | 'TABLE'>('MAP');
 
   if (props.responseData === 'FETCHING') {
     return <MessageContainer>Loading...</MessageContainer>;

--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -60,10 +60,20 @@ interface mapProperties {
 
 const cartogramData: mapProperties[] = require('./assets/data/cartogram-coordinates.json');
 
-const MapNav = styled.div`
+const Container = styled.div`
+  max-width: 600px;
+  margin: 0 auto;
+`;
+
+const MapNav = styled(Container)`
   height: ${NAVHEIGHT}px;
   border-bottom: 1px solid ${props => props.theme.grey};
   display: flex;
+
+  @media (min-width: 600px) {
+    border-left: 1px solid ${props => props.theme.grey};
+    border-right: 1px solid ${props => props.theme.grey};
+  }
 `;
 
 const MapNavButton = styled.button<MapNavProps>`
@@ -72,11 +82,6 @@ const MapNavButton = styled.button<MapNavProps>`
   color: ${props => (props.isActive ? props.theme.white : props.theme.black)};
   border: none;
   font-weight: bold;
-`;
-
-const Container = styled.div`
-  max-width: 600px;
-  margin: 0 auto;
 `;
 
 const MessageContainer = styled.div`

--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -303,7 +303,7 @@ const MapView = (props: MapViewProps) => {
             setActiveView('TABLE');
           }}
         >
-          Kunnittain
+          Valitse kunta
         </MapNavButton>
       </MapNav>
       {activeView === 'MAP' && (

--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -2,13 +2,11 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { RouteComponentProps } from '@reach/router';
 import * as d3 from 'd3';
-import ModalContent from './ModalContent';
-import Modal from './Modal';
 import FilterToggle from './FilterToggle';
 import PrimaryButton from './PrimaryButton';
 import MapContainer from './map/MapContainer';
-import useModal from './useModal';
 import CloseIcon from './assets/CloseIcon';
+import TableView from './TableView';
 import { FILTERS, HEADERHEIGHT, NAVHEIGHT } from './constants';
 
 type FilterKey = keyof typeof FILTERS;
@@ -16,6 +14,10 @@ type FilterKey = keyof typeof FILTERS;
 interface MapViewProps extends RouteComponentProps {
   responseData: any;
 }
+
+type MapNavProps = {
+  isActive: boolean;
+};
 
 interface mapProperties {
   city: string;
@@ -60,8 +62,16 @@ const cartogramData: mapProperties[] = require('./assets/data/cartogram-coordina
 
 const MapNav = styled.div`
   height: ${NAVHEIGHT}px;
-  padding: 0 16px;
-  border-bottom: 1px solid ${props => props.theme.black};
+  border-bottom: 1px solid ${props => props.theme.grey};
+  display: flex;
+`;
+
+const MapNavButton = styled.button<MapNavProps>`
+  width: 50%;
+  background: ${props => (props.isActive ? props.theme.grey : props.theme.white)};
+  color: ${props => (props.isActive ? props.theme.white : props.theme.black)};
+  border: none;
+  font-weight: bold;
 `;
 
 const Container = styled.div`
@@ -72,16 +82,6 @@ const Container = styled.div`
 const MessageContainer = styled.div`
   text-align: center;
   margin: 24px 0;
-`;
-
-const MapNavContent = styled(Container)`
-  height: 100%;
-  display: flex;
-  align-items: center;
-`;
-
-const Label = styled.label`
-  margin-right: 8px;
 `;
 
 const MapWrapper = styled.div`
@@ -171,12 +171,11 @@ const MapView = (props: MapViewProps) => {
   const currentPath = props.location!.pathname;
   const isEmbed = currentPath === '/map-embed';
   const topPartHeight = isEmbed ? NAVHEIGHT : HEADERHEIGHT + NAVHEIGHT;
-  const { isShowing, toggleModal } = useModal();
   const [showMapInfo, setShowMapInfo] = useState(true);
   const [selectedFilter, setSelectedFilter] = useState<FilterKey>(FILTERS.corona_suspicion_yes.id as FilterKey);
   const [mapHeight, setMapHeight] = useState(window.innerHeight - topPartHeight - 10);
-  const [activeCityData, setActiveCityData] = useState({});
   const data = props.responseData.data;
+  const [activeView, setActiveView] = useState<'MAP' | 'TABLE'>('TABLE');
 
   if (props.responseData === 'FETCHING') {
     return <MessageContainer>Loading...</MessageContainer>;
@@ -283,72 +282,68 @@ const MapView = (props: MapViewProps) => {
   return (
     <>
       <MapNav>
-        <MapNavContent>
-          <Label htmlFor="city">Kunta</Label>
-          <select
-            name=""
-            id="city"
-            onChange={(event: { target: { value: string } }) => {
-              let indx = dataForMap.findIndex((obj: { city: string }) => obj.city === event.target.value);
-              setActiveCityData(dataForMap[indx]);
-              toggleModal();
-            }}
-          >
-            <option value="">Valitse kunta...</option>
-            {cities.map((city: string) => {
-              return (
-                <option key={city} value={city}>
-                  {city}
-                </option>
-              );
-            })}
-          </select>
-        </MapNavContent>
+        <MapNavButton
+          type="button"
+          isActive={activeView === 'MAP' ? true : false}
+          onClick={() => {
+            setActiveView('MAP');
+          }}
+        >
+          Koko Suomi
+        </MapNavButton>
+        <MapNavButton
+          type="button"
+          isActive={activeView === 'TABLE' ? true : false}
+          onClick={() => {
+            setActiveView('TABLE');
+          }}
+        >
+          Kunnittain
+        </MapNavButton>
       </MapNav>
-
-      <MapWrapper>
-        <MapContainer
-          mapShapeData={dataForMap}
-          selectedFilter={selectedFilter}
-          mapHeight={mapHeight}
-          popUpOpen={showMapInfo}
-        />
-        <Container>
-          <FilterWrapper>
-            <FilterToggle selectedFilter={selectedFilter} handleFilterChange={handleFilterChange} />
-            <ActiveFilter type="button" label={FILTERS[selectedFilter].label}></ActiveFilter>
-          </FilterWrapper>
-        </Container>
-        <MapInfo>
-          {showMapInfo && (
-            <>
-              <MapInfoContent className="popUp">
-                <CloseButton
-                  type="button"
-                  data-dismiss="modal"
-                  aria-label="Sulje"
-                  onClick={() => setShowMapInfo(false)}
-                >
-                  <CloseIcon />
-                </CloseButton>
-                <p>
-                  Kartta näyttää, millaisia oireita vastaajilla on eri kunnissa. Mukana ovat kunnat, joista on saatu yli
-                  25 vastausta.
-                </p>
-                <p>Kuntien vastauksiin voi tutustua klikkaamalla palloja tai käyttämällä hakuvalikkoa.</p>
-              </MapInfoContent>
-            </>
-          )}
-          <TotalResponses>
-            <Container>
-              <p>Vastauksia yhteensä: {totalResponses.toLocaleString('fi-FI')}</p>
-            </Container>
-          </TotalResponses>
-        </MapInfo>
-      </MapWrapper>
-      <Modal isShowing={isShowing} hide={toggleModal} ariaLabel="Kaupungin tiedot">
-        <ModalContent content={activeCityData} hide={toggleModal} />
-      </Modal>
+      {activeView === 'MAP' && (
+        <MapWrapper>
+          <MapContainer
+            mapShapeData={dataForMap}
+            selectedFilter={selectedFilter}
+            mapHeight={mapHeight}
+            popUpOpen={showMapInfo}
+          />
+          <Container>
+            <FilterWrapper>
+              <FilterToggle selectedFilter={selectedFilter} handleFilterChange={handleFilterChange} />
+              <ActiveFilter type="button" label={FILTERS[selectedFilter].label}></ActiveFilter>
+            </FilterWrapper>
+          </Container>
+          <MapInfo>
+            {showMapInfo && (
+              <>
+                <MapInfoContent className="popUp">
+                  <CloseButton
+                    type="button"
+                    data-dismiss="modal"
+                    aria-label="Sulje"
+                    onClick={() => setShowMapInfo(false)}
+                  >
+                    <CloseIcon />
+                  </CloseButton>
+                  <p>
+                    Kartta näyttää, millaisia oireita vastaajilla on eri kunnissa. Mukana ovat kunnat, joista on saatu
+                    yli 25 vastausta.
+                  </p>
+                  <p>Kuntien vastauksiin voi tutustua klikkaamalla palloja tai käyttämällä hakuvalikkoa.</p>
+                </MapInfoContent>
+              </>
+            )}
+            <TotalResponses>
+              <Container>
+                <p>Vastauksia yhteensä: {totalResponses.toLocaleString('fi-FI')}</p>
+              </Container>
+            </TotalResponses>
+          </MapInfo>
+        </MapWrapper>
+      )}
+      {activeView === 'TABLE' && <TableView data={data} cities={cities}></TableView>}
     </>
   );
 };

--- a/src/frontend/main/ModalContent.tsx
+++ b/src/frontend/main/ModalContent.tsx
@@ -28,11 +28,6 @@ const Description = styled.p`
 `;
 
 const Symptoms = styled.div`
-  p {
-    margin: 0;
-    hyphens: manual;
-  }
-
   td {
     padding-right: 10px;
 
@@ -48,6 +43,7 @@ const Symptoms = styled.div`
   th {
     font-weight: normal;
     text-align: left;
+    hyphens: manual;
   }
 `;
 

--- a/src/frontend/main/ModalContent.tsx
+++ b/src/frontend/main/ModalContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PrimaryButton from './PrimaryButton';
-import ResponseDataHandler from './ResponseDataHandler';
+import handleResponseData from './handleResponseData';
 
 type ModalContentProps = {
   content: any;
@@ -54,7 +54,7 @@ const CloseButton = styled(PrimaryButton)`
 `;
 
 const ModalContent = ({ content, hide }: ModalContentProps) => {
-  const formattedData = ResponseDataHandler(content);
+  const formattedData = handleResponseData(content);
 
   return (
     <>

--- a/src/frontend/main/ModalContent.tsx
+++ b/src/frontend/main/ModalContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PrimaryButton from './PrimaryButton';
+import ResponseDataHandler from './ResponseDataHandler';
 
 type ModalContentProps = {
   content: any;
@@ -21,23 +22,32 @@ const H3 = styled.h3`
   margin-bottom: 0;
 `;
 
-const P = styled.p`
+const Description = styled.p`
   font-style: italic;
-  font-size: 16px;
   margin-top: 0;
 `;
 
 const Symptoms = styled.div`
-  display: grid;
-  grid-template-columns: auto 50px 1fr;
-  grid-gap: 4px 10px;
   p {
     margin: 0;
     hyphens: manual;
   }
 
-  @media (min-width: 350px) {
-    grid-gap: 4px 20px;
+  td {
+    padding-right: 10px;
+
+    &:nth-child(2) {
+      min-width: 60px;
+    }
+
+    @media (min-width: 450px) {
+      padding-right: 20px;
+    }
+  }
+
+  th {
+    font-weight: normal;
+    text-align: left;
   }
 `;
 
@@ -48,66 +58,42 @@ const CloseButton = styled(PrimaryButton)`
 `;
 
 const ModalContent = ({ content, hide }: ModalContentProps) => {
-  const responsesTotal = content.responses !== -1 ? content.responses.toLocaleString('fi-FI') : '< 25';
-  const suspicionTotal =
-    content.corona_suspicion_yes !== -1 ? content.corona_suspicion_yes.toLocaleString('fi-FI') : 'ei tietoa';
-  const coughTotal =
-    content.cough_mild + content.cough_intense !== -2
-      ? (content.cough_mild + content.cough_intense).toLocaleString('fi-FI')
-      : 'ei tietoa';
-  const feverTotal =
-    content.fever_slight + content.fever_high !== -2
-      ? (content.fever_slight + content.fever_high).toLocaleString('fi-FI')
-      : 'ei tietoa';
-  const breathingDifficulties =
-    content.breathing_difficulties_yes !== -1
-      ? content.breathing_difficulties_yes.toLocaleString('fi-FI')
-      : 'ei tietoa';
+  const formattedData = ResponseDataHandler(content);
+
   return (
     <>
       <ModalHeader>
         <H2>{content.city}</H2>
       </ModalHeader>
       <H3>
-        Vastauksia yhteensä: {responsesTotal}{' '}
-        {responsesTotal !== '< 25'
-          ? `(${((content.responses * 100) / content.population).toFixed(2).replace('.', ',')} % väkiluvusta)`
-          : null}
+        Vastauksia yhteensä: {formattedData.responsesTotal} ({formattedData.percentageOfPopulation} % väkiluvusta)
       </H3>
-      <P>{responsesTotal !== '< 25' ? 'Verrattuna kunnan väkilukuun' : null}</P>
+      <Description>{formattedData.responsesTotal !== '< 25' ? 'Verrattuna kunnan väkilukuun' : null}</Description>
       <Symptoms>
-        <span>{suspicionTotal}</span>
-        <span>
-          {content.corona_suspicion_yes !== -1
-            ? `${((content.corona_suspicion_yes * 100) / content.population).toFixed(2).replace('.', ',')} %`
-            : null}
-        </span>
-        <p>Epäilys koronavirus&shy;tartunnasta </p>
-        <span>{coughTotal}</span>
-        <span>
-          {content.cough_mild + content.cough_intense !== -2
-            ? `${(((content.cough_mild + content.cough_intense) * 100) / content.population)
-                .toFixed(2)
-                .replace('.', ',')} %`
-            : null}
-        </span>
-        <p>Yskää</p>
-        <span>{feverTotal}</span>
-        <span>
-          {content.fever_slight + content.fever_high !== -2
-            ? `${(((content.fever_slight + content.fever_high) * 100) / content.population)
-                .toFixed(2)
-                .replace('.', ',')} %`
-            : null}
-        </span>
-        <p>Kuumetta</p>
-        <span>{breathingDifficulties}</span>
-        <span>
-          {content.breathing_difficulties_yes !== -1
-            ? `${((content.breathing_difficulties_yes * 100) / content.population).toFixed(2).replace('.', ',')} %`
-            : null}
-        </span>
-        <p>Vaikeuksia hengittää</p>
+        <table>
+          <tbody>
+            <tr>
+              <td>{formattedData.suspicionTotal}</td>
+              <td>{formattedData.suspicionPercentage} %</td>
+              <th scope="row">Epäilys koronavirus&shy;tartunnasta</th>
+            </tr>
+            <tr>
+              <td>{formattedData.coughTotal}</td>
+              <td>{formattedData.coughPercentage} %</td>
+              <th scope="row">Yskää</th>
+            </tr>
+            <tr>
+              <td>{formattedData.feverTotal}</td>
+              <td>{formattedData.feverPercentage} %</td>
+              <th scope="row">Kuumetta</th>
+            </tr>
+            <tr>
+              <td>{formattedData.breathingDifficultiesTotal}</td>
+              <td>{formattedData.breathingDifficultiesPercentage} %</td>
+              <th scope="row">Vaikeuksia hengittää</th>
+            </tr>
+          </tbody>
+        </table>
       </Symptoms>
       <CloseButton type="button" data-dismiss="modal" aria-label="Sulje" label="Sulje" handleClick={hide} />
     </>

--- a/src/frontend/main/ResponseDataHandler.tsx
+++ b/src/frontend/main/ResponseDataHandler.tsx
@@ -1,0 +1,52 @@
+const ResponseDataHandler = (data: any) => {
+  const responsesTotalValue = data.responses !== -1 ? data.responses.toLocaleString('fi-FI') : '< 25';
+  const percentageOfPopulationValue =
+    responsesTotalValue !== '< 25' ? ((data.responses * 100) / data.population).toFixed(2).replace('.', ',') : null;
+
+  const suspicionTotalValue =
+    data.corona_suspicion_yes !== -1 ? data.corona_suspicion_yes.toLocaleString('fi-FI') : 'ei tietoa';
+  const suspicionPercentageValue =
+    data.corona_suspicion_yes !== -1
+      ? ((data.corona_suspicion_yes * 100) / data.population).toFixed(2).replace('.', ',')
+      : null;
+
+  const coughTotalValue =
+    data.cough_mild + data.cough_intense !== -2
+      ? (data.cough_mild + data.cough_intense).toLocaleString('fi-FI')
+      : 'ei tietoa';
+  const coughPercentageValue =
+    data.cough_mild + data.cough_intense !== -2
+      ? (((data.cough_mild + data.cough_intense) * 100) / data.population).toFixed(2).replace('.', ',')
+      : null;
+
+  const feverTotalValue =
+    data.fever_slight + data.fever_high !== -2
+      ? (data.fever_slight + data.fever_high).toLocaleString('fi-FI')
+      : 'ei tietoa';
+  const feverPercentageValue =
+    data.fever_slight + data.fever_high !== -2
+      ? (((data.fever_slight + data.fever_high) * 100) / data.population).toFixed(2).replace('.', ',')
+      : null;
+
+  const breathingDifficultiesTotalValue =
+    data.breathing_difficulties_yes !== -1 ? data.breathing_difficulties_yes.toLocaleString('fi-FI') : 'ei tietoa';
+  const breathingDifficultiesPercentageValue =
+    data.breathing_difficulties_yes !== -1
+      ? ((data.breathing_difficulties_yes * 100) / data.population).toFixed(2).replace('.', ',')
+      : null;
+
+  return {
+    responsesTotal: responsesTotalValue,
+    percentageOfPopulation: percentageOfPopulationValue,
+    suspicionTotal: suspicionTotalValue,
+    suspicionPercentage: suspicionPercentageValue,
+    coughTotal: coughTotalValue,
+    coughPercentage: coughPercentageValue,
+    feverTotal: feverTotalValue,
+    feverPercentage: feverPercentageValue,
+    breathingDifficultiesTotal: breathingDifficultiesTotalValue,
+    breathingDifficultiesPercentage: breathingDifficultiesPercentageValue,
+  };
+};
+
+export default ResponseDataHandler;

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from 'styled-components';
+
+type TableViewProps = {
+  cities: any;
+  data: any;
+};
+
+const CitySelect = styled.div`
+  height: 58px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid ${props => props.theme.grey};
+  max-width: 600px;
+  margin: 0 auto;
+`;
+
+const Label = styled.label`
+  margin-right: 8px;
+`;
+
+const TableView = ({ data, cities }: TableViewProps) => {
+  console.log(data);
+  return (
+    <>
+      <CitySelect>
+        <Label htmlFor="city">Kunta</Label>
+        <select name="" id="city">
+          <option value="">Kaikki kunnat</option>
+          {cities.map((city: string) => {
+            return (
+              <option key={city} value={city}>
+                {city}
+              </option>
+            );
+          })}
+        </select>
+      </CitySelect>
+      {data.map((item: any) => {
+        return (
+          <div key={item.city}>
+            <h3>{item.city}</h3>
+            <p>Vastauksia yhteensä {item.responses}</p>
+            <table>
+              <thead>
+                <tr>
+                  <th>Oireet</th>
+                  <th>Vastauksia</th>
+                  <th>Osuus väkiluvusta</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>{item.cough_no}</td>
+                  <td>{item.cough_no}</td>
+                  <td>{item.cough_no}</td>
+                </tr>
+                <tr>
+                  <td>{item.cough_no}</td>
+                  <td>{item.cough_no}</td>
+                  <td>{item.cough_no}</td>
+                </tr>
+                <tr>
+                  <td>{item.cough_no}</td>
+                  <td>{item.cough_no}</td>
+                  <td>{item.cough_no}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+export default TableView;

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import ResponseDataHandler from './ResponseDataHandler';
 
@@ -112,11 +112,19 @@ const Label = styled.label`
 `;
 
 const TableView = ({ data, cities }: TableViewProps) => {
+  const [selectedCity, setSelectedCity] = useState('');
+  const cityList =
+    selectedCity === ''
+      ? data
+      : data.filter((item: any) => {
+          return item.city === selectedCity;
+        });
+
   return (
     <>
       <CitySelect>
         <Label htmlFor="city">Kunta</Label>
-        <select name="" id="city">
+        <select name="select" id="city" onChange={e => setSelectedCity(e.currentTarget.value)}>
           <option value="">Kaikki kunnat</option>
           {cities.map((city: string) => {
             return (
@@ -128,7 +136,7 @@ const TableView = ({ data, cities }: TableViewProps) => {
         </select>
       </CitySelect>
       <TableViewWrapper>
-        {data.map((item: any) => {
+        {cityList.map((item: any) => {
           const formattedData = ResponseDataHandler(item);
 
           return (

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import ResponseDataHandler from './ResponseDataHandler';
 
 type TableViewProps = {
-  cities: any;
+  cities: Array<string>;
   data: any;
 };
 

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -36,6 +36,7 @@ const Table = styled.table`
   width: 100%;
   table-layout: fixed;
   border-collapse: collapse;
+  margin-top: 16px;
 
   th {
     font-weight: normal;
@@ -89,18 +90,21 @@ const TableHead = styled.thead`
   }
 `;
 
-const CityHeadingContainer = styled.h2`
+const CityHeadingContainer = styled.div`
   padding: 0 16px;
 `;
 
-const Description = styled.p`
-  font-weight: normal;
+const BoldText = styled.p`
+  font-weight: bold;
+`;
+
+const ItalicText = styled.p`
   font-style: italic;
 `;
 
 const CityHeading = styled.h2`
   font-size: 21px;
-  margin-bottom: 8px;
+  margin: 18px 0 8px;
 `;
 
 const Label = styled.label`
@@ -131,8 +135,8 @@ const TableView = ({ data, cities }: TableViewProps) => {
             <TableContainer key={item.city}>
               <CityHeadingContainer>
                 <CityHeading>{item.city}</CityHeading>
-                <p>Vastauksia yhteensä {formattedData.responsesTotal}</p>
-                <Description>{formattedData.percentageOfPopulation} % väkiluvusta</Description>
+                <BoldText>Vastauksia yhteensä {formattedData.responsesTotal}</BoldText>
+                <ItalicText>{formattedData.percentageOfPopulation} % väkiluvusta</ItalicText>
               </CityHeadingContainer>
               <Table>
                 <TableHead>

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import ResponseDataHandler from './ResponseDataHandler';
+import handleResponseData from './handleResponseData';
 
 type TableViewProps = {
   cities: Array<string>;
@@ -137,7 +137,7 @@ const TableView = ({ data, cities }: TableViewProps) => {
       </CitySelect>
       <TableViewWrapper>
         {cityList.map((item: any) => {
-          const formattedData = ResponseDataHandler(item);
+          const formattedData = handleResponseData(item);
 
           return (
             <TableContainer key={item.city}>

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import ResponseDataHandler from './ResponseDataHandler';
 
 type TableViewProps = {
   cities: any;
@@ -16,12 +17,97 @@ const CitySelect = styled.div`
   margin: 0 auto;
 `;
 
+const TableViewWrapper = styled.div`
+  max-width: 600px;
+  margin: 0 auto;
+`;
+
+const TableContainer = styled.div`
+  width: 100%;
+  border-bottom: 1px solid ${props => props.theme.grey};
+  padding: 0 0 24px 0;
+
+  p {
+    margin: 0 0 4px 0;
+  }
+`;
+
+const Table = styled.table`
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+
+  th {
+    font-weight: normal;
+
+    &:nth-child(1) {
+      text-align: left;
+    }
+  }
+
+  th,
+  td {
+    padding: 1px 4px;
+    width: 90px;
+
+    @media (min-width: 450px) {
+      padding-left: 0;
+      width: 140px;
+    }
+  }
+
+  th:nth-child(1),
+  td:nth-child(1) {
+    padding-left: 16px;
+    width: auto;
+  }
+
+  th:nth-child(3),
+  td:nth-child(3) {
+    padding-right: 16px;
+  }
+
+  td {
+    text-align: center;
+  }
+
+  tbody tr:nth-child(1) {
+    th,
+    td {
+      padding-top: 8px;
+    }
+  }
+`;
+
+const TableHead = styled.thead`
+  background: ${props => props.theme.lightGrey};
+
+  th {
+    padding: 6px 4px;
+    font-style: italic;
+    font-size: 14px;
+  }
+`;
+
+const CityHeadingContainer = styled.h2`
+  padding: 0 16px;
+`;
+
+const Description = styled.p`
+  font-weight: normal;
+  font-style: italic;
+`;
+
+const CityHeading = styled.h2`
+  font-size: 21px;
+  margin-bottom: 8px;
+`;
+
 const Label = styled.label`
   margin-right: 8px;
 `;
 
 const TableView = ({ data, cities }: TableViewProps) => {
-  console.log(data);
   return (
     <>
       <CitySelect>
@@ -37,40 +123,52 @@ const TableView = ({ data, cities }: TableViewProps) => {
           })}
         </select>
       </CitySelect>
-      {data.map((item: any) => {
-        return (
-          <div key={item.city}>
-            <h3>{item.city}</h3>
-            <p>Vastauksia yhteensä {item.responses}</p>
-            <table>
-              <thead>
-                <tr>
-                  <th>Oireet</th>
-                  <th>Vastauksia</th>
-                  <th>Osuus väkiluvusta</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{item.cough_no}</td>
-                  <td>{item.cough_no}</td>
-                  <td>{item.cough_no}</td>
-                </tr>
-                <tr>
-                  <td>{item.cough_no}</td>
-                  <td>{item.cough_no}</td>
-                  <td>{item.cough_no}</td>
-                </tr>
-                <tr>
-                  <td>{item.cough_no}</td>
-                  <td>{item.cough_no}</td>
-                  <td>{item.cough_no}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        );
-      })}
+      <TableViewWrapper>
+        {data.map((item: any) => {
+          const formattedData = ResponseDataHandler(item);
+
+          return (
+            <TableContainer key={item.city}>
+              <CityHeadingContainer>
+                <CityHeading>{item.city}</CityHeading>
+                <p>Vastauksia yhteensä {formattedData.responsesTotal}</p>
+                <Description>{formattedData.percentageOfPopulation} % väkiluvusta</Description>
+              </CityHeadingContainer>
+              <Table>
+                <TableHead>
+                  <tr>
+                    <th>Oireet</th>
+                    <th>Vastauksia</th>
+                    <th>Osuus väkiluvusta</th>
+                  </tr>
+                </TableHead>
+                <tbody>
+                  <tr>
+                    <th scope="row">Epäilys koronavirus&shy;tartunnasta</th>
+                    <td>{formattedData.suspicionTotal}</td>
+                    <td>{formattedData.suspicionPercentage} %</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Yskää</th>
+                    <td>{formattedData.coughTotal}</td>
+                    <td>{formattedData.coughPercentage} %</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Kuumetta</th>
+                    <td>{formattedData.feverTotal}</td>
+                    <td>{formattedData.feverPercentage} %</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">Vaikeuksia hengittää</th>
+                    <td>{formattedData.breathingDifficultiesTotal}</td>
+                    <td>{formattedData.breathingDifficultiesPercentage} %</td>
+                  </tr>
+                </tbody>
+              </Table>
+            </TableContainer>
+          );
+        })}
+      </TableViewWrapper>
     </>
   );
 };

--- a/src/frontend/main/constants.ts
+++ b/src/frontend/main/constants.ts
@@ -6,4 +6,4 @@ export const FILTERS = {
 };
 
 export const HEADERHEIGHT = 90;
-export const NAVHEIGHT = 55;
+export const NAVHEIGHT = 40;

--- a/src/frontend/main/handleResponseData.tsx
+++ b/src/frontend/main/handleResponseData.tsx
@@ -1,4 +1,4 @@
-const ResponseDataHandler = (data: any) => {
+const handleResponseData = (data: any) => {
   const responsesTotalValue = data.responses !== -1 ? data.responses.toLocaleString('fi-FI') : '< 25';
   const percentageOfPopulationValue =
     responsesTotalValue !== '< 25' ? ((data.responses * 100) / data.population).toFixed(2).replace('.', ',') : null;
@@ -49,4 +49,4 @@ const ResponseDataHandler = (data: any) => {
   };
 };
 
-export default ResponseDataHandler;
+export default handleResponseData;


### PR DESCRIPTION
- Adding a new city level data view, that lists all cities and their response data in tables
- Adding a navigation for switching between the map and city level view
- Moving the city select in the table view, filtering the list based on the selected city
- Adding a `ResponseDataHandler` that returns response and symptom counts and percentage values since they are now needed in two different places (`ModalContent` and the `TableView`). Not sure if this is the best way to do it, any suggestions are welcome and this can be refactored later if needed.

The table view on smaller screens
![image](https://user-images.githubusercontent.com/5812075/80469630-7ebaa300-8949-11ea-86cc-825d7338b404.png)

-------------
Selecting a city
![image](https://user-images.githubusercontent.com/5812075/80469679-9134dc80-8949-11ea-992c-29728154a224.png)

-------------
Larger screens
![image](https://user-images.githubusercontent.com/5812075/80469724-a3167f80-8949-11ea-80f0-493a2a133803.png)
