### PR TITLE
Add borders to map nav buttons in embed view

### DIFF
--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -17,6 +17,7 @@ interface MapViewProps extends RouteComponentProps {
 
 type MapNavProps = {
   isActive: boolean;
+  isEmbed: boolean;
 };
 
 interface mapProperties {
@@ -69,11 +70,6 @@ const MapNav = styled(Container)`
   height: ${NAVHEIGHT}px;
   border-bottom: 1px solid ${props => props.theme.grey};
   display: flex;
-
-  @media (min-width: 600px) {
-    border-left: 1px solid ${props => props.theme.grey};
-    border-right: 1px solid ${props => props.theme.grey};
-  }
 `;
 
 const MapNavButton = styled.button<MapNavProps>`
@@ -82,6 +78,22 @@ const MapNavButton = styled.button<MapNavProps>`
   color: ${props => (props.isActive ? props.theme.white : props.theme.black)};
   border: none;
   font-weight: bold;
+  border-top: ${props => (props.isEmbed ? `1px solid ${props.theme.grey}` : 'none')};
+
+  &:nth-child(1) {
+    border-left: ${props => (props.isEmbed ? `1px solid ${props.theme.grey}` : 'none')};
+
+    @media (min-width: 600px) {
+      border-left: 1px solid ${props => props.theme.grey};
+    }
+  }
+
+  &:nth-child(2) {
+    border-right: ${props => (props.isEmbed ? `1px solid ${props.theme.grey}` : 'none')};
+    @media (min-width: 600px) {
+      border-right: 1px solid ${props => props.theme.grey};
+    }
+  }
 `;
 
 const MessageContainer = styled.div`
@@ -290,6 +302,7 @@ const MapView = (props: MapViewProps) => {
         <MapNavButton
           type="button"
           isActive={activeView === 'MAP' ? true : false}
+          isEmbed={isEmbed}
           onClick={() => {
             setActiveView('MAP');
           }}
@@ -299,6 +312,7 @@ const MapView = (props: MapViewProps) => {
         <MapNavButton
           type="button"
           isActive={activeView === 'TABLE' ? true : false}
+          isEmbed={isEmbed}
           onClick={() => {
             setActiveView('TABLE');
           }}


### PR DESCRIPTION
The map is embedded to articles without the header, so the map nav buttons didn't have a top border (which normally is the header's bottom border). 

Now it should be like this on the normal site
Small screen
![image](https://user-images.githubusercontent.com/5812075/80491625-a4f13a80-896b-11ea-9769-e1cd3382041a.png)

Bigger screen
![image](https://user-images.githubusercontent.com/5812075/80491340-3f04b300-896b-11ea-90ac-785d7c6a31a5.png)


And like this in the embed version `/map-embed`
Small screen 
![image](https://user-images.githubusercontent.com/5812075/80491709-c18d7280-896b-11ea-95a1-f461622a1fee.png)


Bigger screen 
![image](https://user-images.githubusercontent.com/5812075/80491447-63f92600-896b-11ea-8e53-ebf9ca9a61d3.png)
