### PR TITLE
Edit form header paddings and add a fix for local development

### DIFF
--- a/src/frontend/embed/v1/index.css
+++ b/src/frontend/embed/v1/index.css
@@ -25,7 +25,7 @@ body {
 }
 
 header {
-  padding: 24px 24px 10px;
+  padding: 24px 2px 10px 2px;
   border-bottom: 1px solid #000;
   height: 130px;
   background-color: #fff;

--- a/src/index-frontend-embed-v1.ts
+++ b/src/index-frontend-embed-v1.ts
@@ -42,6 +42,10 @@ function currentDisplayLanguage() {
           .substring(currentPage.length - 7)
           .replace('.html', '')
           .toLowerCase();
+  // For local development
+  if (currentPage === '/') {
+    lang = '';
+  }
   if (lang !== '') {
     $('#language-selector option[value=' + lang + ']').attr('selected', 'selected');
   } else {


### PR DESCRIPTION
Made the header padding smaller, the embed does not need it since the articles usually have a padding. Screenshots from the article embeds:

Before (on very small screen)
![image](https://user-images.githubusercontent.com/5812075/80569246-2e9f1780-8a01-11ea-9f67-1953cc992ea7.png)

---
After
![image](https://user-images.githubusercontent.com/5812075/80569204-18915700-8a01-11ea-90fe-e2f5fc7933e7.png)

The code related to languages was causing errors while developing locally, so I also added a fix for that. 
