### PR TITLE
Improve error descriptions around S3 operations and storage

### DIFF
--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -58,23 +58,30 @@ export function createS3Client() {
 // S3 fetch helpers
 
 export async function s3GetJsonHelper(s3: AWS.S3, params: AWS.S3.GetObjectRequest) {
-  const result = await s3.getObject(params).promise();
-  if (!result.Body) {
-    throw Error(`Empty JSON in S3 object '${params.Bucket}/${params.Key}`);
+  try {
+    const result = await s3.getObject(params).promise();
+    if (!result.Body) {
+      throw Error(`Empty JSON in S3 object "${params.Bucket}/${params.Key}"`);
+    }
+    return JSON.parse(result.Body.toString('utf-8'));
+  } catch (err) {
+    throw new Error(`Couldn't get JSON from S3 object "${params.Bucket}/${params.Key}" (caused by\n${err}\n)`);
   }
-
-  return JSON.parse(result.Body.toString('utf-8'));
 }
 
 export async function s3PutJsonHelper(s3: AWS.S3, params: AWS.S3.PutObjectRequest) {
-  return await s3
-    .putObject({
-      ...params,
-      ContentType: 'application/json',
-      CacheControl: 'max-age=15',
-      Body: JSON.stringify(params.Body, null, 2),
-    })
-    .promise();
+  try {
+    return await s3
+      .putObject({
+        ...params,
+        ContentType: 'application/json',
+        CacheControl: 'max-age=15',
+        Body: JSON.stringify(params.Body, null, 2),
+      })
+      .promise();
+  } catch (err) {
+    throw new Error(`Couldn't put JSON to S3 object "${params.Bucket}/${params.Key}" (caused by\n${err}\n)`);
+  }
 }
 
 export function createS3Sources(appConstants: AppConstants, s3Client: AWS.S3) {

--- a/src/index-backend.ts
+++ b/src/index-backend.ts
@@ -86,7 +86,7 @@ if (process.argv[0].match(/\/ts-node$/)) {
 
 const response = (statusCode: number, body?: object, logError?: Error) => {
   console.log(`Outgoing response: ${statusCode}`);
-  if (logError) console.error('ERROR (API)', logError);
+  if (logError) console.error(`API request processing failed (caused by\n${logError}\n)`);
   return {
     statusCode,
     body: body ? JSON.stringify(body, null, 2) : '',


### PR DESCRIPTION
Now, this isn't exactly pretty (maybe @cutepig has ideas on prettifying it?), but this PR turns the previously somewhat cryptic API error:

```
ERROR (API) AccessDenied: Access Denied
    at Request.extractError (/var/runtime/node_modules/aws-sdk/lib/services/s3.js:816:35)
    at Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/var/runtime/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/var/runtime/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /var/runtime/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:116:18)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/var/runtime/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/var/runtime/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /var/runtime/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:38:9) {
  message: 'Access Denied',
  code: 'AccessDenied',
  region: null,
  time: 2020-04-29T08:56:51.766Z,
  requestId: 'CF791B7D850C56CC',
  extendedRequestId: 'Vm/45e1bjUBoxsI+vRgAtTasPfdAlFyMqyQbHx7etTlbqOjbSsWmuAK0amObA68vfYzxmXkRwiE=',
  cfId: undefined,
  statusCode: 403,
  retryable: false,
  retryDelay: 4.375497904653702
}
```

to:

```
API request processing failed (caused by
Error: Couldn't obfuscate low population postal code "99999" (caused by
Error: Couldn't get JSON from S3 object "symptomradar-dev-open-data/low_population_postal_codes.json" (caused by
AccessDenied: Access Denied
)
)
)
```