### PR TITLE
Fix Lambda permissions for backend API.

### DIFF
--- a/infra/modules/main/backend.tf
+++ b/infra/modules/main/backend.tf
@@ -75,6 +75,18 @@ resource "aws_iam_policy" "backend_api" {
       "Effect": "Allow"
     },
     {
+      "Sid": "ReadOnlyAccessToOpenDataBucket",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${aws_s3_bucket.open_data.id}",
+        "arn:aws:s3:::${aws_s3_bucket.open_data.id}/*"
+      ],
+      "Effect": "Allow"
+    },
+    {
       "Sid": "ReadOnlyAccessToSecrets",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
Fixes API Lambda permissions to match #269 (to account for `obfuscateLowPopulationPostalCode()`)