### PR TITLE
Fix handling low response data

### DIFF
--- a/src/frontend/main/ModalContent.tsx
+++ b/src/frontend/main/ModalContent.tsx
@@ -62,7 +62,10 @@ const ModalContent = ({ content, hide }: ModalContentProps) => {
         <H2>{content.city}</H2>
       </ModalHeader>
       <H3>
-        Vastauksia yhteensä: {formattedData.responsesTotal} ({formattedData.percentageOfPopulation} % väkiluvusta)
+        Vastauksia yhteensä: {formattedData.responsesTotal}{' '}
+        {formattedData.percentageOfPopulation != null
+          ? `(${formattedData.percentageOfPopulation} % väkiluvusta)`
+          : null}
       </H3>
       <Description>{formattedData.responsesTotal !== '< 25' ? 'Verrattuna kunnan väkilukuun' : null}</Description>
       <Symptoms>
@@ -70,22 +73,24 @@ const ModalContent = ({ content, hide }: ModalContentProps) => {
           <tbody>
             <tr>
               <td>{formattedData.suspicionTotal}</td>
-              <td>{formattedData.suspicionPercentage} %</td>
+              {formattedData.suspicionPercentage != null ? <td>{formattedData.suspicionPercentage} %</td> : null}
               <th scope="row">Epäilys koronavirus&shy;tartunnasta</th>
             </tr>
             <tr>
               <td>{formattedData.coughTotal}</td>
-              <td>{formattedData.coughPercentage} %</td>
+              {formattedData.coughPercentage != null ? <td>{formattedData.coughPercentage} %</td> : null}
               <th scope="row">Yskää</th>
             </tr>
             <tr>
               <td>{formattedData.feverTotal}</td>
-              <td>{formattedData.feverPercentage} %</td>
+              {formattedData.feverPercentage != null ? <td>{formattedData.feverPercentage} %</td> : null}
               <th scope="row">Kuumetta</th>
             </tr>
             <tr>
               <td>{formattedData.breathingDifficultiesTotal}</td>
-              <td>{formattedData.breathingDifficultiesPercentage} %</td>
+              {formattedData.breathingDifficultiesPercentage != null ? (
+                <td>{formattedData.breathingDifficultiesPercentage} %</td>
+              ) : null}
               <th scope="row">Vaikeuksia hengittää</th>
             </tr>
           </tbody>

--- a/src/frontend/main/ModalContent.tsx
+++ b/src/frontend/main/ModalContent.tsx
@@ -67,7 +67,7 @@ const ModalContent = ({ content, hide }: ModalContentProps) => {
           ? `(${formattedData.percentageOfPopulation} % väkiluvusta)`
           : null}
       </H3>
-      <Description>{formattedData.responsesTotal !== '< 25' ? 'Verrattuna kunnan väkilukuun' : null}</Description>
+      {formattedData.responsesTotal !== '< 25' ? <Description>Verrattuna kunnan väkilukuun</Description> : null}
       <Symptoms>
         <table>
           <tbody>

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -156,11 +156,10 @@ const TableView = ({ data, cities, isEmbed }: TableViewProps) => {
               <CityHeadingContainer>
                 <CityHeading>{item.city}</CityHeading>
                 <BoldText>Vastauksia yhteensä {formattedData.responsesTotal}</BoldText>
-                <ItalicText>
-                  {formattedData.percentageOfPopulation != null
-                    ? `${formattedData.percentageOfPopulation} % väkiluvusta`
-                    : null}
-                </ItalicText>
+
+                {formattedData.percentageOfPopulation != null ? (
+                  <ItalicText>{formattedData.percentageOfPopulation} % väkiluvusta</ItalicText>
+                ) : null}
               </CityHeadingContainer>
               <Table>
                 <TableHead>

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -156,7 +156,11 @@ const TableView = ({ data, cities, isEmbed }: TableViewProps) => {
               <CityHeadingContainer>
                 <CityHeading>{item.city}</CityHeading>
                 <BoldText>Vastauksia yhteensä {formattedData.responsesTotal}</BoldText>
-                <ItalicText>{formattedData.percentageOfPopulation} % väkiluvusta</ItalicText>
+                <ItalicText>
+                  {formattedData.percentageOfPopulation != null
+                    ? `${formattedData.percentageOfPopulation} % väkiluvusta`
+                    : null}
+                </ItalicText>
               </CityHeadingContainer>
               <Table>
                 <TableHead>
@@ -170,22 +174,28 @@ const TableView = ({ data, cities, isEmbed }: TableViewProps) => {
                   <tr>
                     <th scope="row">Epäilys koronavirus&shy;tartunnasta</th>
                     <td>{formattedData.suspicionTotal}</td>
-                    <td>{formattedData.suspicionPercentage} %</td>
+                    <td>
+                      {formattedData.suspicionPercentage != null ? `${formattedData.suspicionPercentage} %` : '-'}
+                    </td>
                   </tr>
                   <tr>
                     <th scope="row">Yskää</th>
                     <td>{formattedData.coughTotal}</td>
-                    <td>{formattedData.coughPercentage} %</td>
+                    <td>{formattedData.coughPercentage != null ? `${formattedData.coughPercentage} %` : '-'}</td>
                   </tr>
                   <tr>
                     <th scope="row">Kuumetta</th>
                     <td>{formattedData.feverTotal}</td>
-                    <td>{formattedData.feverPercentage} %</td>
+                    <td>{formattedData.feverPercentage != null ? `${formattedData.feverPercentage} %` : '-'}</td>
                   </tr>
                   <tr>
                     <th scope="row">Vaikeuksia hengittää</th>
                     <td>{formattedData.breathingDifficultiesTotal}</td>
-                    <td>{formattedData.breathingDifficultiesPercentage} %</td>
+                    <td>
+                      {formattedData.breathingDifficultiesPercentage != null
+                        ? `${formattedData.breathingDifficultiesPercentage} %`
+                        : '-'}
+                    </td>
                   </tr>
                 </tbody>
               </Table>


### PR DESCRIPTION
If a city has less than 25 responses, the content now looks like this
![image](https://user-images.githubusercontent.com/5812075/80596461-10501080-8a2f-11ea-8569-9b733f4f7d22.png)
![image](https://user-images.githubusercontent.com/5812075/80596548-3b3a6480-8a2f-11ea-807f-f0032e48c16f.png)

