### PR TITLE
Load more content on scroll

### DIFF
--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -1,0 +1,219 @@
+import React, { useState, useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import handleResponseData from './handleResponseData';
+import { NAVHEIGHT, CITYSELECTHEIGHT } from './constants';
+
+type CityTablesProps = {
+  cityList: any;
+  isEmbed: boolean;
+};
+
+type TableViewWrapperProps = {
+  isEmbed: boolean;
+};
+
+const Table = styled.table`
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+  margin-top: 16px;
+
+  th {
+    font-weight: normal;
+
+    &:nth-child(1) {
+      text-align: left;
+    }
+  }
+
+  th,
+  td {
+    padding: 1px 4px;
+    width: 90px;
+
+    @media (min-width: 450px) {
+      padding-left: 0;
+      width: 140px;
+    }
+  }
+
+  th:nth-child(1),
+  td:nth-child(1) {
+    padding-left: 16px;
+    width: auto;
+  }
+
+  th:nth-child(3),
+  td:nth-child(3) {
+    padding-right: 16px;
+  }
+
+  td {
+    text-align: center;
+  }
+
+  tbody tr:nth-child(1) {
+    th,
+    td {
+      padding-top: 8px;
+    }
+  }
+`;
+
+const TableContainer = styled.div`
+  width: 100%;
+  border-bottom: 1px solid ${props => props.theme.grey};
+  padding: 0 0 24px 0;
+
+  p {
+    margin: 0 0 4px 0;
+  }
+`;
+
+const CityHeadingContainer = styled.div`
+  padding: 0 16px;
+`;
+
+const BoldText = styled.p`
+  font-weight: bold;
+`;
+
+const ItalicText = styled.p`
+  font-style: italic;
+`;
+
+const CityHeading = styled.h2`
+  font-size: 21px;
+  margin: 18px 0 8px;
+`;
+
+const TableHead = styled.thead`
+  background: ${props => props.theme.lightGrey};
+
+  th {
+    padding: 6px 4px;
+    font-style: italic;
+    font-size: 14px;
+  }
+`;
+
+const Loading = styled.p`
+  margin-top: 40px;
+`;
+
+const TableViewWrapper = styled.div<TableViewWrapperProps>`
+  max-width: 600px;
+  margin: 0 auto;
+  padding-bottom: 40px;
+  height: ${props => (props.isEmbed ? `calc(100vh - (${CITYSELECTHEIGHT}px + ${NAVHEIGHT}px))` : 'auto')};
+  overflow: ${props => (props.isEmbed ? 'auto' : 'initial')};
+`;
+
+const CityTables = ({ cityList, isEmbed }: CityTablesProps) => {
+  const [listItems, setListItems] = useState(cityList.slice(0, 10));
+  const [isFetching, setIsFetching] = useState(false);
+  const container = useRef<HTMLDivElement>(null);
+
+  console.log(cityList);
+  console.log(listItems);
+  if (cityList.length === 1) {
+    setListItems(cityList);
+  }
+
+  // For the main site, where the page is scrolled
+  const handleWindowScroll = () => {
+    if (!isEmbed && cityList.length > 1) {
+      if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight) return;
+      setIsFetching(true);
+    }
+  };
+
+  // For article embeds, where the the container is scrolled
+  const handleContainerScroll = () => {
+    if (isEmbed && container.current !== null && cityList.length > 1) {
+      var scrollY = container.current.scrollHeight - container.current.scrollTop;
+      var height = container.current.offsetHeight;
+      var offset = height - scrollY;
+
+      if (offset === 0 || offset === 1) {
+        setIsFetching(true);
+      }
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleWindowScroll);
+    return () => window.removeEventListener('scroll', handleWindowScroll);
+  }, []);
+
+  useEffect(() => {
+    if (!isFetching) return;
+    fetchMoreListItems();
+  }, [isFetching]);
+
+  function fetchMoreListItems() {
+    setTimeout(() => {
+      setListItems((prevState: any) => [...prevState, ...cityList.slice(prevState.length, prevState.length + 10)]);
+      setIsFetching(false);
+    }, 2000);
+  }
+
+  return (
+    <TableViewWrapper isEmbed={isEmbed} ref={container} onScroll={handleContainerScroll}>
+      {listItems.map((item: any) => {
+        const formattedData = handleResponseData(item);
+
+        return (
+          <TableContainer key={item.city}>
+            <CityHeadingContainer>
+              <CityHeading>{item.city}</CityHeading>
+              <BoldText>Vastauksia yhteensä {formattedData.responsesTotal}</BoldText>
+
+              {formattedData.percentageOfPopulation != null ? (
+                <ItalicText>{formattedData.percentageOfPopulation} % väkiluvusta</ItalicText>
+              ) : null}
+            </CityHeadingContainer>
+            <Table>
+              <TableHead>
+                <tr>
+                  <th>Oireet</th>
+                  <th>Vastauksia</th>
+                  <th>Osuus väkiluvusta</th>
+                </tr>
+              </TableHead>
+              <tbody>
+                <tr>
+                  <th scope="row">Epäilys koronavirus&shy;tartunnasta</th>
+                  <td>{formattedData.suspicionTotal}</td>
+                  <td>{formattedData.suspicionPercentage != null ? `${formattedData.suspicionPercentage} %` : '-'}</td>
+                </tr>
+                <tr>
+                  <th scope="row">Yskää</th>
+                  <td>{formattedData.coughTotal}</td>
+                  <td>{formattedData.coughPercentage != null ? `${formattedData.coughPercentage} %` : '-'}</td>
+                </tr>
+                <tr>
+                  <th scope="row">Kuumetta</th>
+                  <td>{formattedData.feverTotal}</td>
+                  <td>{formattedData.feverPercentage != null ? `${formattedData.feverPercentage} %` : '-'}</td>
+                </tr>
+                <tr>
+                  <th scope="row">Vaikeuksia hengittää</th>
+                  <td>{formattedData.breathingDifficultiesTotal}</td>
+                  <td>
+                    {formattedData.breathingDifficultiesPercentage != null
+                      ? `${formattedData.breathingDifficultiesPercentage} %`
+                      : '-'}
+                  </td>
+                </tr>
+              </tbody>
+            </Table>
+          </TableContainer>
+        );
+      })}
+      {isFetching && <Loading>Ladataan...</Loading>}
+    </TableViewWrapper>
+  );
+};
+
+export default CityTables;

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import handleResponseData from './handleResponseData';
 import { NAVHEIGHT, CITYSELECTHEIGHT } from './constants';
@@ -115,13 +115,23 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
   const [isFetching, setIsFetching] = useState(false);
   const container = useRef<HTMLDivElement>(null);
 
+  const fetchMoreListItems = useCallback(() => {
+    if (isFetching) return;
+    setIsFetching(true);
+
+    setTimeout(() => {
+      setListItems((prevState: any) => [...prevState, ...data.slice(prevState.length, prevState.length + 10)]);
+      setIsFetching(false);
+    }, 2000);
+  }, [data, isFetching]);
+
   // For the main site, where the page is scrolled
-  const handleWindowScroll = () => {
+  const handleWindowScroll = useCallback(() => {
     if (!isEmbed && selectedCity === '' && data.length > listItems.length) {
       if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight) return;
       fetchMoreListItems();
     }
-  };
+  }, [isEmbed, selectedCity, data, fetchMoreListItems, listItems]);
 
   // For article embeds, where the the container is scrolled
   const handleContainerScroll = () => {
@@ -134,16 +144,6 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
         fetchMoreListItems();
       }
     }
-  };
-
-  const fetchMoreListItems = () => {
-    if (isFetching) return;
-    setIsFetching(true);
-
-    setTimeout(() => {
-      setListItems((prevState: any) => [...prevState, ...data.slice(prevState.length, prevState.length + 10)]);
-      setIsFetching(false);
-    }, 2000);
   };
 
   useEffect(() => {
@@ -159,7 +159,7 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
   useEffect(() => {
     window.addEventListener('scroll', handleWindowScroll);
     return () => window.removeEventListener('scroll', handleWindowScroll);
-  }, [listItems]);
+  }, [handleWindowScroll, listItems]);
 
   return (
     <TableViewWrapper isEmbed={isEmbed} ref={container} onScroll={handleContainerScroll}>

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -119,7 +119,7 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
   const handleWindowScroll = () => {
     if (!isEmbed && selectedCity === '' && data.length > listItems.length) {
       if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight) return;
-      setIsFetching(true);
+      fetchMoreListItems();
     }
   };
 
@@ -131,9 +131,19 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
       var offset = height - scrollY;
 
       if (offset === 0 || offset === 1) {
-        setIsFetching(true);
+        fetchMoreListItems();
       }
     }
+  };
+
+  const fetchMoreListItems = () => {
+    if (isFetching) return;
+    setIsFetching(true);
+
+    setTimeout(() => {
+      setListItems((prevState: any) => [...prevState, ...data.slice(prevState.length, prevState.length + 10)]);
+      setIsFetching(false);
+    }, 2000);
   };
 
   useEffect(() => {
@@ -144,24 +154,12 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
             return item.city === selectedCity;
           });
     setListItems(cityList.slice(0, 10));
-  }, [selectedCity]);
+  }, [data, selectedCity]);
 
   useEffect(() => {
     window.addEventListener('scroll', handleWindowScroll);
     return () => window.removeEventListener('scroll', handleWindowScroll);
   }, [listItems]);
-
-  useEffect(() => {
-    if (!isFetching) return;
-    fetchMoreListItems();
-  }, [isFetching]);
-
-  function fetchMoreListItems() {
-    setTimeout(() => {
-      setListItems((prevState: any) => [...prevState, ...data.slice(prevState.length, prevState.length + 10)]);
-      setIsFetching(false);
-    }, 2000);
-  }
 
   return (
     <TableViewWrapper isEmbed={isEmbed} ref={container} onScroll={handleContainerScroll}>

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -4,7 +4,8 @@ import handleResponseData from './handleResponseData';
 import { NAVHEIGHT, CITYSELECTHEIGHT } from './constants';
 
 type CityTablesProps = {
-  cityList: any;
+  data: any;
+  selectedCity: string;
   isEmbed: boolean;
 };
 
@@ -109,20 +110,14 @@ const TableViewWrapper = styled.div<TableViewWrapperProps>`
   overflow: ${props => (props.isEmbed ? 'auto' : 'initial')};
 `;
 
-const CityTables = ({ cityList, isEmbed }: CityTablesProps) => {
-  const [listItems, setListItems] = useState(cityList.slice(0, 10));
+const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
+  const [listItems, setListItems] = useState(data.slice(0, 10));
   const [isFetching, setIsFetching] = useState(false);
   const container = useRef<HTMLDivElement>(null);
 
-  console.log(cityList);
-  console.log(listItems);
-  if (cityList.length === 1) {
-    setListItems(cityList);
-  }
-
   // For the main site, where the page is scrolled
   const handleWindowScroll = () => {
-    if (!isEmbed && cityList.length > 1) {
+    if (!isEmbed && selectedCity === '' && data.length > listItems.length) {
       if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight) return;
       setIsFetching(true);
     }
@@ -130,7 +125,7 @@ const CityTables = ({ cityList, isEmbed }: CityTablesProps) => {
 
   // For article embeds, where the the container is scrolled
   const handleContainerScroll = () => {
-    if (isEmbed && container.current !== null && cityList.length > 1) {
+    if (isEmbed && container.current !== null && selectedCity === '' && data.length > listItems.length) {
       var scrollY = container.current.scrollHeight - container.current.scrollTop;
       var height = container.current.offsetHeight;
       var offset = height - scrollY;
@@ -142,9 +137,19 @@ const CityTables = ({ cityList, isEmbed }: CityTablesProps) => {
   };
 
   useEffect(() => {
+    const cityList =
+      selectedCity === ''
+        ? data
+        : data.filter((item: any) => {
+            return item.city === selectedCity;
+          });
+    setListItems(cityList.slice(0, 10));
+  }, [selectedCity]);
+
+  useEffect(() => {
     window.addEventListener('scroll', handleWindowScroll);
     return () => window.removeEventListener('scroll', handleWindowScroll);
-  }, []);
+  }, [listItems]);
 
   useEffect(() => {
     if (!isFetching) return;
@@ -153,7 +158,7 @@ const CityTables = ({ cityList, isEmbed }: CityTablesProps) => {
 
   function fetchMoreListItems() {
     setTimeout(() => {
-      setListItems((prevState: any) => [...prevState, ...cityList.slice(prevState.length, prevState.length + 10)]);
+      setListItems((prevState: any) => [...prevState, ...data.slice(prevState.length, prevState.length + 10)]);
       setIsFetching(false);
     }, 2000);
   }

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -150,9 +150,11 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
   }, [data, selectedCity]);
 
   useEffect(() => {
+    if (!isEmbed) {
     window.addEventListener('scroll', handleWindowScroll);
     return () => window.removeEventListener('scroll', handleWindowScroll);
-  }, [handleWindowScroll, listItems]);
+    }
+  }, [isEmbed, handleWindowScroll, listItems]);
 
   return (
     <TableViewWrapper isEmbed={isEmbed} ref={container} onScroll={handleContainerScroll}>

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -98,10 +98,6 @@ const TableHead = styled.thead`
   }
 `;
 
-const Loading = styled.p`
-  margin-top: 40px;
-`;
-
 const TableViewWrapper = styled.div<TableViewWrapperProps>`
   max-width: 600px;
   margin: 0 auto;
@@ -118,11 +114,8 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
   const fetchMoreListItems = useCallback(() => {
     if (isFetching) return;
     setIsFetching(true);
-
-    setTimeout(() => {
-      setListItems((prevState: any) => [...prevState, ...data.slice(prevState.length, prevState.length + 10)]);
-      setIsFetching(false);
-    }, 2000);
+    setListItems((prevState: any) => [...prevState, ...data.slice(prevState.length, prevState.length + 10)]);
+    setIsFetching(false);
   }, [data, isFetching]);
 
   // For the main site, where the page is scrolled
@@ -214,7 +207,6 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
           </TableContainer>
         );
       })}
-      {isFetching && <Loading>Ladataan...</Loading>}
     </TableViewWrapper>
   );
 };

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -120,11 +120,14 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
 
   // For the main site, where the page is scrolled
   const handleWindowScroll = useCallback(() => {
-    if (!isEmbed && selectedCity === '' && data.length > listItems.length) {
-      if (window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight) return;
-      fetchMoreListItems();
-    }
-  }, [isEmbed, selectedCity, data, fetchMoreListItems, listItems]);
+    if (
+      selectedCity !== '' ||
+      data.length === listItems.length ||
+      window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight
+    )
+      return;
+    fetchMoreListItems();
+  }, [selectedCity, data, fetchMoreListItems, listItems]);
 
   // For article embeds, where the the container is scrolled
   const handleContainerScroll = () => {
@@ -151,8 +154,8 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
 
   useEffect(() => {
     if (!isEmbed) {
-    window.addEventListener('scroll', handleWindowScroll);
-    return () => window.removeEventListener('scroll', handleWindowScroll);
+      window.addEventListener('scroll', handleWindowScroll);
+      return () => window.removeEventListener('scroll', handleWindowScroll);
     }
   }, [isEmbed, handleWindowScroll, listItems]);
 

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -29,12 +29,6 @@ const Label = styled.label`
 
 const TableView = ({ data, cities, isEmbed }: TableViewProps) => {
   const [selectedCity, setSelectedCity] = useState('');
-  const cityList =
-    selectedCity === ''
-      ? data
-      : data.filter((item: any) => {
-          return item.city === selectedCity;
-        });
 
   return (
     <>
@@ -51,7 +45,7 @@ const TableView = ({ data, cities, isEmbed }: TableViewProps) => {
           })}
         </select>
       </CitySelect>
-      <CityTables cityList={cityList} isEmbed={isEmbed} />
+      <CityTables data={data} selectedCity={selectedCity} isEmbed={isEmbed} />
     </>
   );
 };

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -1,15 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import handleResponseData from './handleResponseData';
-import { NAVHEIGHT, CITYSELECTHEIGHT } from './constants';
+import CityTables from './CityTables';
+import { CITYSELECTHEIGHT } from './constants';
 
 type TableViewProps = {
   cities: Array<string>;
   data: any;
-  isEmbed: boolean;
-};
-
-type TableViewWrapperProps = {
   isEmbed: boolean;
 };
 
@@ -25,98 +21,6 @@ const CitySelect = styled.div`
   select {
     max-width: 200px;
   }
-`;
-
-const TableViewWrapper = styled.div<TableViewWrapperProps>`
-  max-width: 600px;
-  margin: 0 auto;
-  height: ${props => (props.isEmbed ? `calc(100vh - (${CITYSELECTHEIGHT}px + ${NAVHEIGHT}px))` : 'auto')};
-  overflow: ${props => (props.isEmbed ? 'auto' : 'initial')};
-`;
-
-const TableContainer = styled.div`
-  width: 100%;
-  border-bottom: 1px solid ${props => props.theme.grey};
-  padding: 0 0 24px 0;
-
-  p {
-    margin: 0 0 4px 0;
-  }
-`;
-
-const Table = styled.table`
-  width: 100%;
-  table-layout: fixed;
-  border-collapse: collapse;
-  margin-top: 16px;
-
-  th {
-    font-weight: normal;
-
-    &:nth-child(1) {
-      text-align: left;
-    }
-  }
-
-  th,
-  td {
-    padding: 1px 4px;
-    width: 90px;
-
-    @media (min-width: 450px) {
-      padding-left: 0;
-      width: 140px;
-    }
-  }
-
-  th:nth-child(1),
-  td:nth-child(1) {
-    padding-left: 16px;
-    width: auto;
-  }
-
-  th:nth-child(3),
-  td:nth-child(3) {
-    padding-right: 16px;
-  }
-
-  td {
-    text-align: center;
-  }
-
-  tbody tr:nth-child(1) {
-    th,
-    td {
-      padding-top: 8px;
-    }
-  }
-`;
-
-const TableHead = styled.thead`
-  background: ${props => props.theme.lightGrey};
-
-  th {
-    padding: 6px 4px;
-    font-style: italic;
-    font-size: 14px;
-  }
-`;
-
-const CityHeadingContainer = styled.div`
-  padding: 0 16px;
-`;
-
-const BoldText = styled.p`
-  font-weight: bold;
-`;
-
-const ItalicText = styled.p`
-  font-style: italic;
-`;
-
-const CityHeading = styled.h2`
-  font-size: 21px;
-  margin: 18px 0 8px;
 `;
 
 const Label = styled.label`
@@ -147,61 +51,7 @@ const TableView = ({ data, cities, isEmbed }: TableViewProps) => {
           })}
         </select>
       </CitySelect>
-      <TableViewWrapper isEmbed={isEmbed}>
-        {cityList.map((item: any) => {
-          const formattedData = handleResponseData(item);
-
-          return (
-            <TableContainer key={item.city}>
-              <CityHeadingContainer>
-                <CityHeading>{item.city}</CityHeading>
-                <BoldText>Vastauksia yhteensä {formattedData.responsesTotal}</BoldText>
-
-                {formattedData.percentageOfPopulation != null ? (
-                  <ItalicText>{formattedData.percentageOfPopulation} % väkiluvusta</ItalicText>
-                ) : null}
-              </CityHeadingContainer>
-              <Table>
-                <TableHead>
-                  <tr>
-                    <th>Oireet</th>
-                    <th>Vastauksia</th>
-                    <th>Osuus väkiluvusta</th>
-                  </tr>
-                </TableHead>
-                <tbody>
-                  <tr>
-                    <th scope="row">Epäilys koronavirus&shy;tartunnasta</th>
-                    <td>{formattedData.suspicionTotal}</td>
-                    <td>
-                      {formattedData.suspicionPercentage != null ? `${formattedData.suspicionPercentage} %` : '-'}
-                    </td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Yskää</th>
-                    <td>{formattedData.coughTotal}</td>
-                    <td>{formattedData.coughPercentage != null ? `${formattedData.coughPercentage} %` : '-'}</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Kuumetta</th>
-                    <td>{formattedData.feverTotal}</td>
-                    <td>{formattedData.feverPercentage != null ? `${formattedData.feverPercentage} %` : '-'}</td>
-                  </tr>
-                  <tr>
-                    <th scope="row">Vaikeuksia hengittää</th>
-                    <td>{formattedData.breathingDifficultiesTotal}</td>
-                    <td>
-                      {formattedData.breathingDifficultiesPercentage != null
-                        ? `${formattedData.breathingDifficultiesPercentage} %`
-                        : '-'}
-                    </td>
-                  </tr>
-                </tbody>
-              </Table>
-            </TableContainer>
-          );
-        })}
-      </TableViewWrapper>
+      <CityTables cityList={cityList} isEmbed={isEmbed} />
     </>
   );
 };


### PR DESCRIPTION
Implementing infinity scroll for the TableView (listing all city data). More data is loaded when the end of the page (on oiretutka.fi) or the container (in the embed version) is reached. The tables were moved to a separate component CityTables, where all loading and list filtering happens.

The update was done because loading the whole city list inside an article embed was a bit too much on slow connections and devices with low memory (or at least on my Android phone it made the whole app crash).
