### PR TITLE
Skip counting responses for -1 values

### DIFF
--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -217,7 +217,7 @@ const MapView = (props: MapViewProps) => {
   };
 
   const totalResponses = data.reduce((accumulator: number, currentValue: any) => {
-    if (currentValue.responses === -1) return accumulator;
+    if (currentValue.responses < 0) return accumulator;
     return accumulator + currentValue.responses;
   }, 0);
 

--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -217,6 +217,7 @@ const MapView = (props: MapViewProps) => {
   };
 
   const totalResponses = data.reduce((accumulator: number, currentValue: any) => {
+    if (currentValue.responses === -1) return accumulator;
     return accumulator + currentValue.responses;
   }, 0);
 


### PR DESCRIPTION
If the city has less than 25 responses, it is marked -1 in the data. This changes the total response calculation to skip those values.