### PR TITLE
Load more data a bit before reaching the bottom

### DIFF
--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -120,10 +120,11 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
 
   // For the main site, where the page is scrolled
   const handleWindowScroll = useCallback(() => {
+    const scrollTop = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop);
     if (
       selectedCity !== '' ||
       data.length === listItems.length ||
-      window.innerHeight + document.documentElement.scrollTop + 20 < document.documentElement.offsetHeight
+      window.innerHeight + scrollTop + 40 < document.documentElement.offsetHeight
     )
       return;
     fetchMoreListItems();
@@ -136,7 +137,7 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
       var height = container.current.offsetHeight;
       var offset = height - scrollY;
 
-      if (offset === 0 || offset === 1) {
+      if (offset > -40) {
         fetchMoreListItems();
       }
     }

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -123,7 +123,7 @@ const CityTables = ({ data, selectedCity, isEmbed }: CityTablesProps) => {
     if (
       selectedCity !== '' ||
       data.length === listItems.length ||
-      window.innerHeight + document.documentElement.scrollTop !== document.documentElement.offsetHeight
+      window.innerHeight + document.documentElement.scrollTop + 20 < document.documentElement.offsetHeight
     )
       return;
     fetchMoreListItems();


### PR DESCRIPTION
On some browser + OS combinations (at least Firefox & Linux) the calculation was not reliable. This adds some threshold so it's not required to scroll all the way to the bottom, more content will be loaded a bit before reaching it.
Also some mobile browsers handle these in different ways, some improvements added to make it work better on all devices.