### PR TITLE
Move height constants into theme

### DIFF
--- a/src/frontend/main/App.tsx
+++ b/src/frontend/main/App.tsx
@@ -8,6 +8,7 @@ import About from './About';
 import Survey from './Survey';
 import Privacy from './Privacy';
 import Menu from './Menu';
+import { theme } from './constants';
 
 import RobotoEot from './assets/fonts/roboto-v20-latin-ext_latin-regular.eot';
 import RobotoSvg from './assets/fonts/roboto-v20-latin-ext_latin-regular.svg';
@@ -19,15 +20,6 @@ import Roboto700Svg from './assets/fonts/roboto-v20-latin-ext_latin-700.svg';
 import Roboto700Ttf from './assets/fonts/roboto-v20-latin-ext_latin-700.ttf';
 import Roboto700Woff from './assets/fonts/roboto-v20-latin-ext_latin-700.woff';
 import Roboto700Woff2 from './assets/fonts/roboto-v20-latin-ext_latin-700.woff2';
-
-const theme = {
-  grey: '#757575',
-  lightGrey: '#ECECEC',
-  white: '#FFFFFF',
-  black: '#000000',
-  blue: '#0047FF',
-  green: '#328709',
-};
 
 const GlobalStyles = createGlobalStyle`
 

--- a/src/frontend/main/CityTables.tsx
+++ b/src/frontend/main/CityTables.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import handleResponseData from './handleResponseData';
-import { NAVHEIGHT, CITYSELECTHEIGHT } from './constants';
 
 type CityTablesProps = {
   data: any;
@@ -102,7 +101,7 @@ const TableViewWrapper = styled.div<TableViewWrapperProps>`
   max-width: 600px;
   margin: 0 auto;
   padding-bottom: 40px;
-  height: ${props => (props.isEmbed ? `calc(100vh - (${CITYSELECTHEIGHT}px + ${NAVHEIGHT}px))` : 'auto')};
+  height: ${({ isEmbed, theme }) => (isEmbed ? `calc(100vh - ${theme.citySelectHeight + theme.navHeight}px)` : 'auto')};
   overflow: ${props => (props.isEmbed ? 'auto' : 'initial')};
 `;
 

--- a/src/frontend/main/Header.tsx
+++ b/src/frontend/main/Header.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { Link } from '@reach/router';
 import Logo from './assets/oiretutka-logo-gradient.svg';
 import MenuButton from './MenuButton';
-import { HEADERHEIGHT } from './constants';
 
 type HeaderProps = {
   location: string;
@@ -15,7 +14,7 @@ const AppHeader = styled.header`
   padding: 16px 16px 10px 16px;
   background-color: ${props => props.theme.white};
   border-bottom: 1px solid ${props => props.theme.grey};
-  height: ${HEADERHEIGHT}px;
+  height: ${({ theme }) => theme.headerHeight}px;
 `;
 
 const HeaderContainer = styled.div`

--- a/src/frontend/main/MapView.tsx
+++ b/src/frontend/main/MapView.tsx
@@ -7,7 +7,8 @@ import PrimaryButton from './PrimaryButton';
 import MapContainer from './map/MapContainer';
 import CloseIcon from './assets/CloseIcon';
 import TableView from './TableView';
-import { FILTERS, HEADERHEIGHT, NAVHEIGHT } from './constants';
+import { theme } from './constants';
+import { FILTERS } from './constants';
 
 type FilterKey = keyof typeof FILTERS;
 
@@ -71,7 +72,7 @@ const Container = styled.div`
 `;
 
 const MapNav = styled(Container)`
-  height: ${NAVHEIGHT}px;
+  height: ${props => props.theme.navHeight}px;
   border-bottom: 1px solid ${props => props.theme.grey};
   display: flex;
 `;
@@ -108,7 +109,7 @@ const MessageContainer = styled.div`
 const MapWrapper = styled.div`
   text-align: center;
   position: relative;
-  height: calc(100vh - (${HEADERHEIGHT}px + ${NAVHEIGHT}px));
+  height: calc(100vh - ${({ theme }) => theme.headerHeight + theme.navHeight}px);
 `;
 
 const FilterWrapper = styled.div<FilterWrapperProps>`
@@ -191,7 +192,8 @@ const CloseButton = styled.button`
 const MapView = (props: MapViewProps) => {
   const currentPath = props.location!.pathname;
   const isEmbed = currentPath === '/map-embed';
-  const topPartHeight = isEmbed ? NAVHEIGHT : HEADERHEIGHT + NAVHEIGHT;
+  const { navHeight, headerHeight } = theme;
+  const topPartHeight = isEmbed ? navHeight : headerHeight + navHeight;
   const [showMapInfo, setShowMapInfo] = useState(true);
   const [selectedFilter, setSelectedFilter] = useState<FilterKey>(FILTERS.corona_suspicion_yes.id as FilterKey);
   const [mapHeight, setMapHeight] = useState(window.innerHeight - topPartHeight - 10);

--- a/src/frontend/main/TableView.tsx
+++ b/src/frontend/main/TableView.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import CityTables from './CityTables';
-import { CITYSELECTHEIGHT } from './constants';
 
 type TableViewProps = {
   cities: Array<string>;
@@ -10,7 +9,7 @@ type TableViewProps = {
 };
 
 const CitySelect = styled.div`
-  height: ${CITYSELECTHEIGHT}px;
+  height: ${({ theme }) => theme.citySelectHeight}px;
   padding: 0 16px;
   display: flex;
   align-items: center;

--- a/src/frontend/main/constants.ts
+++ b/src/frontend/main/constants.ts
@@ -5,6 +5,14 @@ export const FILTERS = {
   breathing_difficulties_yes: { label: 'Vaikeuksia hengittää', id: 'breathing_difficulties_yes' },
 };
 
-export const HEADERHEIGHT = 90;
-export const NAVHEIGHT = 40;
-export const CITYSELECTHEIGHT = 58;
+export const theme = {
+  grey: '#757575',
+  lightGrey: '#ECECEC',
+  white: '#FFFFFF',
+  black: '#000000',
+  blue: '#0047FF',
+  green: '#328709',
+  headerHeight: 90,
+  navHeight: 40,
+  citySelectHeight: 58,
+};


### PR DESCRIPTION
The PR moved HEADERHEIGHT, NAVHEIGHT and CITYSELECTHEIGHT to a part inside styled-component's theme.

`theme` was moved to `constants.ts` file to avoid circular import when  `App.tsx` imports `MapView` and `MapView` imports `theme` from `App.tsx`
