### PR TITLE
Remove inline script and use a div for showing loader

### DIFF
--- a/public/index-embed-v1.html
+++ b/public/index-embed-v1.html
@@ -22,7 +22,7 @@
         </select>
       </div>
     </header>
-    <main>
+    <main class="hidden">
       <div class="container">
         <div id="form-info" class="form-info">
           <h1 id="page-title" tabindex="-1">
@@ -58,10 +58,10 @@
             {{ thank_you_help }}
           </p>
         </div>
-        <button id="start-survey" class="button action-button">{{ start_survey }}</button>
+        <button id="start-survey" class="button action-button hidden">{{ start_survey }}</button>
       </div>
       <form id="symptom-questionnaire" class="hidden" novalidate>
-        <button id="collapse-survey" type="button" class="collapse-button">{{ close_survey }}</button>
+        <button id="collapse-survey" type="button" class="collapse-button hidden">{{ close_survey }}</button>
         <div class="question-group">
           <h2 id="form-header" class="question-group-title" tabindex="-1">{{ what_symptoms_headline }}</h2>
           <fieldset class="input-wrapper">

--- a/public/index-embed-v1.html
+++ b/public/index-embed-v1.html
@@ -4,42 +4,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ title }}</title>
-    <style>
-      @keyframes dot-dot-doh {
-        0%   {content:"."}
-        33%  {content:".."}
-        66%  {content:"..."}
-        100% {content:"."}
-      }
-
-      /* Only display loading animation if JavaScript is enabled */
-      .loader::before {;
-        content: ".";
-        font-size: 32px;
-        display: block;
-        width: 100%;
-        height: 10px;
-        animation-name: dot-dot-doh;
-        animation-duration: 1.2s;
-        animation-iteration-count: infinite;
-      }
-
-      /*
-      * Prevent flickering by hiding `main` and `header` section by default.
-      * After js files are loaded, the app's css files will be appended to the
-      * document and set them to visible again.
-      */
-      main,
-      header {
-        display: none;
-      }
-    </style>
   </head>
 
   <body>
     <noscript>{{ no_js }}</noscript>
-    <div class="loader"></div>
-    <header>
+    <header class="hidden">
       <img
         id="logo"
         class="logo"

--- a/public/index-embed-v1.html
+++ b/public/index-embed-v1.html
@@ -13,7 +13,7 @@
       }
 
       /* Only display loading animation if JavaScript is enabled */
-      body.js-enabled::before{;
+      .loader::before {;
         content: ".";
         font-size: 32px;
         display: block;
@@ -38,9 +38,7 @@
 
   <body>
     <noscript>{{ no_js }}</noscript>
-    <script>
-      document.body.classList.add("js-enabled");
-    </script>
+    <div class="loader"></div>
     <header>
       <img
         id="logo"

--- a/src/frontend/embed/v1/index.css
+++ b/src/frontend/embed/v1/index.css
@@ -20,15 +20,23 @@ body {
 }
 
 @keyframes dot-dot-doh {
-  0%   {content:"."}
-  33%  {content:".."}
-  66%  {content:"..."}
-  100% {content:"."}
+  0% {
+    content: '.';
+  }
+  33% {
+    content: '..';
+  }
+  66% {
+    content: '...';
+  }
+  100% {
+    content: '.';
+  }
 }
 
 /* Show loader while waiting for js files */
 body::before {
-  content: ".";
+  content: '.';
   font-size: 32px;
   display: block;
   width: 100%;

--- a/src/frontend/embed/v1/index.css
+++ b/src/frontend/embed/v1/index.css
@@ -19,8 +19,27 @@ body {
   background-color: #ffffff;
 }
 
-/* hide loader after the app is fully loaded */
-.loader {
+@keyframes dot-dot-doh {
+  0%   {content:"."}
+  33%  {content:".."}
+  66%  {content:"..."}
+  100% {content:"."}
+}
+
+/* Show loader while waiting for js files */
+body::before {
+  content: ".";
+  font-size: 32px;
+  display: block;
+  width: 100%;
+  height: 10px;
+  animation-name: dot-dot-doh;
+  animation-duration: 1.2s;
+  animation-iteration-count: infinite;
+}
+
+/* Hide loader when js files are loaded */
+body.js-loaded::before {
   display: none;
 }
 

--- a/src/frontend/embed/v1/index.css
+++ b/src/frontend/embed/v1/index.css
@@ -19,8 +19,8 @@ body {
   background-color: #ffffff;
 }
 
-/* hide spinner after the app is fully loaded */
-body.js-enabled::before {
+/* hide loader after the app is fully loaded */
+.loader {
   display: none;
 }
 

--- a/src/index-frontend-embed-v1.ts
+++ b/src/index-frontend-embed-v1.ts
@@ -156,25 +156,6 @@ function initValidation() {
     .change(inputChanged);
 }
 
-const variant = getUrlParameter('variant');
-
-function setVariant() {
-  // Embedding only the form
-  if (variant === 'plain') {
-    $('header, #start-survey, #collapse-survey').addClass('hidden');
-    $('body').addClass('plain');
-    $('#symptom-questionnaire').removeClass('hidden');
-    $('#start-survey').addClass('hidden');
-    initValidation();
-  }
-
-  const returningUser = isReturningUser();
-  if (returningUser) {
-    $('#form-info').addClass('hidden');
-    $('#form-info-returning').removeClass('hidden');
-  }
-}
-
 function hideSurvey() {
   $('#symptom-questionnaire').addClass('hidden');
   $('#start-survey').removeClass('hidden');
@@ -208,7 +189,27 @@ function hideSubmitError() {
   $('#submit-error').addClass('hidden');
 }
 
+const variant = getUrlParameter('variant');
+
 function init() {
+  $('body').addClass('js-loaded');
+  $('main').removeClass('hidden');
+
+  // Embedding only the form
+  if (variant === 'plain') {
+    $('body').addClass('plain');
+    $('#symptom-questionnaire').removeClass('hidden');
+    initValidation();
+  } else {
+    $('header, #start-survey, #collapse-survey').removeClass('hidden');
+  }
+
+  const returningUser = isReturningUser();
+  if (returningUser) {
+    $('#form-info').addClass('hidden');
+    $('#form-info-returning').removeClass('hidden');
+  }
+
   const endpoint = process.env.REACT_APP_API_ENDPOINT;
   if (!endpoint) {
     console.error('Endpoint url missing');
@@ -277,10 +278,5 @@ function init() {
       .fail(() => showSubmitError('Tietojen lähetys epäonnistui', 'Ole hyvä ja yritä uudelleen.'));
   });
 }
-
-// `setVariant` hides and show elements based on the defined variant.
-// This function is called immediately without waiting for `document.ready` to
-// avoid noticable flickering of delayed style changes.
-setVariant();
 
 $(document).ready(init);


### PR DESCRIPTION
My PR adds a fix for production flickering issues. Because development server uses inline css (probably to accommodate hot reloading) while css files in production and rendered together with index.html file, the reliable way to test is to create a build version and test the that build bundle instead of relying on local dev:

```
npm run frontend-embed-v1-build && npx serve build -p 3000
```
