### PR TITLE
Experiment/Local lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ npm run open-data-cli dump total_responses.json -- --out=/tmp/total_responses.js
 
 ### Running backend locally
 
-To run the backend locally, use the following NPM script that starts a small Node.js server that wraps the Lambdas in `src/index-backend.ts`:
+To run the backend locally, use the following NPM script that starts a small Node.js server on port 3001 that wraps the Lambdas in `src/index-backend.ts`:
 
 ```sh
 npm run backend-start
@@ -280,7 +280,7 @@ npm run backend-start
 After that you can call the Lambda functions with HTTP requests:
 
 ```sh
-curl http://localhost:3000/workerEntrypoint
+curl http://localhost:3001/workerEntrypoint
 ```
 
 _NOTE: There is lot of room for improvements on this solution, for e.g using [SAM](https://aws.amazon.com/serverless/sam/) or [serverless](https://github.com/serverless/serverless) that would provide better integration for AWS Lambda surface. Currently it's pretty much an ugly hack wrapping the current needs of current endpoints into a simple Node.js server._

--- a/README.md
+++ b/README.md
@@ -269,6 +269,22 @@ npm run --silent open-data-cli dump total_responses.json > /tmp/total_responses.
 npm run open-data-cli dump total_responses.json -- --out=/tmp/total_responses.json
 ```
 
+### Running backend locally
+
+To run the backend locally, use the following NPM script that starts a small Node.js server that wraps the Lambdas in `src/index-backend.ts`:
+
+```sh
+npm run backend-start
+```
+
+After that you can call the Lambda functions with HTTP requests:
+
+```sh
+curl http://localhost:3000/workerEntrypoint
+```
+
+_NOTE: There is lot of room for improvements on this solution, for e.g using [SAM](https://aws.amazon.com/serverless/sam/) or [serverless](https://github.com/serverless/serverless) that would provide better integration for AWS Lambda surface. Currently it's pretty much an ugly hack wrapping the current needs of current endpoints into a simple Node.js server._
+
 ## MIT License
 
 Copyright 2020 Futurice & Helsingin Sanomat

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "frontend-embed-v1-start": "npm run lint-node && npm run set-frontend embed-v1 && BROWSER=none react-scripts start",
     "frontend-embed-v1-build": "npm run lint-node && npm run set-frontend embed-v1 && react-scripts build",
     "\n==================== BACKEND ====================": "",
+    "backend-start": "npm run ts-node src/index-dev-backend",
     "backend-build": "npm run lint-node && rm -rf build && tsc --project tsconfig-backend.json",
     "\n==================== UTILS ====================": "",
     "set-frontend": "/usr/bin/env bash -c 'set -x; (cd src/ && ln -fs index-frontend-$1.ts* index.tsx); (cd public/ && ln -fs index-$1.html index.html)' --",

--- a/src/backend/local.ts
+++ b/src/backend/local.ts
@@ -1,0 +1,77 @@
+import http from 'http';
+import { parse as parseUrl } from 'url';
+import { APIGatewayProxyHandler, APIGatewayProxyEventBase, Context, APIGatewayProxyResult } from 'aws-lambda';
+
+import * as entrypoints from '../index-backend';
+import { AddressInfo } from 'net';
+
+const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
+  const url = parseUrl(req.url!);
+  const { pathname } = url;
+  const name = pathname!.slice(1) as keyof typeof entrypoints;
+
+  console.log(`${req.method} ${req.url}`);
+
+  console.log(`Checking for entrypoint ${name} (${pathname})`);
+
+  //
+  // Rudimentary routing
+  const entrypoint = entrypoints[name] as APIGatewayProxyHandler;
+
+  if (!entrypoint) {
+    res.writeHead(404);
+    res.end();
+    return;
+  }
+
+  //
+  // Parse request and execute
+  Promise.resolve()
+    // Read body data
+    .then(() => {
+      return new Promise<string>((resolve, reject) => {
+        const data: string[] = [];
+        req.on('data', chunk => {
+          data.push(chunk);
+        });
+        req.on('end', () => {
+          resolve(data.join(''));
+        });
+      });
+    })
+    // Map request
+    .then(
+      body =>
+        ({
+          httpMethod: req.method,
+          path: pathname,
+          headers: { ...req.headers },
+          body: body,
+          requestContext: {
+            identity: {
+              sourceIp: '127.0.0.1',
+            },
+          },
+        } as APIGatewayProxyEventBase<any>),
+    )
+    // Execute
+    .then(event => entrypoint(event, {} as Context, x => x) as Promise<APIGatewayProxyResult>)
+    .then(
+      _res =>
+        _res || {
+          statusCode: 200,
+          headers: {},
+          body: '',
+        },
+    )
+    .then(_res => {
+      res.writeHead(_res.statusCode, _res.headers as any);
+      res.write(_res.body);
+      res.end();
+    });
+});
+
+server.listen(3000, () => {
+  const addr = (server.address as unknown) as AddressInfo;
+  console.log(`Listening at ${addr.address}:${addr.port} (${addr.family})`);
+});

--- a/src/backend/local.ts
+++ b/src/backend/local.ts
@@ -72,6 +72,6 @@ const server = http.createServer((req: http.IncomingMessage, res: http.ServerRes
 });
 
 server.listen(3000, () => {
-  const addr = (server.address as unknown) as AddressInfo;
-  console.log(`Listening at ${addr.address}:${addr.port} (${addr.family})`);
+  const addr = server.address() as AddressInfo;
+  console.log(`Local development server started at ${addr.address}:${addr.port} (${addr.family})`);
 });

--- a/src/index-backend.ts
+++ b/src/index-backend.ts
@@ -43,6 +43,11 @@ export const workerEntrypoint: Handler<unknown> = async () => {
   }
 };
 
+export const ping: Handler<unknown> = async () => {
+  console.log('Ping');
+  return response(200, { pong: 'pong' });
+};
+
 if (process.argv[0].match(/\/ts-node$/)) {
   const test: FrontendResponseModelT = {
     participant_id: uuidV4(),

--- a/src/index-dev-backend.ts
+++ b/src/index-dev-backend.ts
@@ -71,7 +71,7 @@ const server = http.createServer((req: http.IncomingMessage, res: http.ServerRes
     });
 });
 
-server.listen(3000, () => {
+server.listen(3001, () => {
   const addr = server.address() as AddressInfo;
   console.log(`Local development server started at ${addr.address}:${addr.port} (${addr.family})`);
 });

--- a/src/index-dev-backend.ts
+++ b/src/index-dev-backend.ts
@@ -2,7 +2,7 @@ import http from 'http';
 import { parse as parseUrl } from 'url';
 import { APIGatewayProxyHandler, APIGatewayProxyEventBase, Context, APIGatewayProxyResult } from 'aws-lambda';
 
-import * as entrypoints from '../index-backend';
+import * as entrypoints from './index-backend';
 import { AddressInfo } from 'net';
 
 const server = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {


### PR DESCRIPTION
Allows you to run the lambda functions locally with a simple Node.js HTTP server wrapped over the lambda endpoints.

Run the lambdas locally with the following NPM script:

```sh
npm run backend-start
```

After that you can call the lambda functions with HTTP requests:

```sh
curl http://localhost:3001/workerEntrypoint
```

> _NOTE: There is lot of room for improvements on this solution, for e.g using [SAM](https://aws.amazon.com/serverless/sam/) or [serverless](https://github.com/serverless/serverless) that would provide better integration for AWS Lambda surface. Currently it's pretty much an ugly hack wrapping the current needs of current endpoints into a simple Node.js server._