### PR TITLE
City level daily totals data dump

### DIFF
--- a/src/backend/app.ts
+++ b/src/backend/app.ts
@@ -48,6 +48,7 @@ export function createAppConstants() {
     cityLevelPastWeekGeneralResultsKey: 'city_level_past_week_general_results.json',
     postalCodeLevelGeneralResultsKey: 'postalcode_level_general_results.json',
     dailyTotalsKey: 'daily_totals.json',
+    cityLevelDailyTotalsKey: 'city_level_daily_totals.json',
   };
 }
 

--- a/src/backend/appMocks.ts
+++ b/src/backend/appMocks.ts
@@ -80,6 +80,7 @@ export function createMockApp(overrides: Partial<App> = {}): App {
     cityLevelPastWeekGeneralResultsKey: 'city_level_past_week_general_results.json',
     postalCodeLevelGeneralResultsKey: 'postalcode_level_general_results.json',
     dailyTotalsKey: 'daily_totals.json',
+    cityLevelDailyTotalsKey: 'city_level_daily_totals.json',
   };
 
   const mockApp: App = {

--- a/src/backend/cli.ts
+++ b/src/backend/cli.ts
@@ -3,16 +3,18 @@ import { promisify } from 'util';
 import yargs from 'yargs';
 import { createApp, App, AppConstants } from './app';
 import { fetchOpenDataIndex, pushOpenDataIndex } from './dataExports/openDataIndex';
-import { fetchTotalResponses, pushTotalResponses } from './dataExports/totalResponses';
+import { fetchTotalResponses, pushTotalResponses, totalResponsesQuery } from './dataExports/totalResponses';
 import { fetchCityLevelGeneralResults, pushCityLevelGeneralResults } from './dataExports/cityLevelGeneralResults';
 import {
   fetchCityLevelPastWeekGeneralResults,
   pushCityLevelPastWeekGeneralResults,
+  postalCodeLevelWeeklyGeneralResultsQuery,
 } from './dataExports/cityLevelPastWeekGeneralResults';
-import { fetchDailyTotals, pushDailyTotals } from './dataExports/dailyTotals';
+import { fetchDailyTotals, pushDailyTotals, dailyTotalsQuery } from './dataExports/dailyTotals';
 import {
   fetchPostalCodeLevelGeneralResults,
   pushPostalCodeLevelGeneralResults,
+  postalCodeLevelGeneralResultsQuery,
 } from './dataExports/postalCodeLevelGeneralResults';
 
 const writeFile = promisify(fs.writeFile);
@@ -22,6 +24,7 @@ const app = createApp();
 interface DataExportHandler {
   fetch(app: App): Promise<any>;
   push(app: App, data: any): Promise<void>;
+  query?: string;
 }
 
 const dataExportHandlers: { [K in keyof AppConstants]?: DataExportHandler } = {
@@ -32,20 +35,24 @@ const dataExportHandlers: { [K in keyof AppConstants]?: DataExportHandler } = {
   [app.constants.totalResponsesKey]: {
     fetch: fetchTotalResponses,
     push: pushTotalResponses,
+    query: totalResponsesQuery,
   },
   [app.constants.cityLevelGeneralResultsKey]: {
     fetch: fetchCityLevelGeneralResults,
     push: pushCityLevelGeneralResults,
+    query: postalCodeLevelGeneralResultsQuery,
   },
   [app.constants.cityLevelPastWeekGeneralResultsKey]: {
     fetch: fetchCityLevelPastWeekGeneralResults,
     push: pushCityLevelPastWeekGeneralResults,
+    query: postalCodeLevelWeeklyGeneralResultsQuery,
   },
   [app.constants.postalCodeLevelGeneralResultsKey]: {
     fetch: fetchPostalCodeLevelGeneralResults,
     push: pushPostalCodeLevelGeneralResults,
+    query: postalCodeLevelGeneralResultsQuery,
   },
-  [app.constants.dailyTotalsKey]: { fetch: fetchDailyTotals, push: pushDailyTotals },
+  [app.constants.dailyTotalsKey]: { fetch: fetchDailyTotals, push: pushDailyTotals, query: dailyTotalsQuery },
 };
 
 interface CommonArgs {
@@ -95,6 +102,24 @@ yargs
         process.exit(1);
       }
     },
+  )
+  .command(
+    'show-query [filename]',
+    'Shows Athena query forgiven data file',
+    yargs => {
+      yargs.positional('filename', {
+        describe: 'Filename of open data file',
+        choices: Object.keys(dataExportHandlers),
+      });
+    },
+    async args => {
+      try {
+        await showQueryCommand(args as any);
+      } catch (error) {
+        console.error(error);
+        process.exit(1);
+      }
+    },
   ).argv;
 
 interface DumpArgs extends CommonArgs {
@@ -136,4 +161,17 @@ export async function exportCommand(args: ExportArgs) {
   await handler.push(app, data);
 
   console.log(`Exported "${filename}"`);
+}
+
+export async function showQueryCommand(args: ExportArgs) {
+  const { filename } = args;
+
+  const handler = dataExportHandlers[filename as keyof AppConstants];
+  if (!handler) {
+    throw Error(`Unknown filename "${filename}"`);
+  }
+
+  if (handler.query) {
+    console.log(handler.query);
+  }
 }

--- a/src/backend/cli.ts
+++ b/src/backend/cli.ts
@@ -116,7 +116,7 @@ yargs
   )
   .command(
     'show-query [filename]',
-    'Shows Athena query forgiven data file',
+    'Shows Athena query for given data file',
     yargs => {
       yargs.positional('filename', {
         describe: 'Filename of open data file',

--- a/src/backend/cli.ts
+++ b/src/backend/cli.ts
@@ -16,6 +16,11 @@ import {
   pushPostalCodeLevelGeneralResults,
   postalCodeLevelGeneralResultsQuery,
 } from './dataExports/postalCodeLevelGeneralResults';
+import {
+  fetchCityLevelDailyTotals,
+  pushCityLevelDailyTotals,
+  postalCodeLevelDailyTotalsQuery,
+} from './dataExports/cityLevelDailyTotals';
 
 const writeFile = promisify(fs.writeFile);
 
@@ -53,6 +58,12 @@ const dataExportHandlers: { [K in keyof AppConstants]?: DataExportHandler } = {
     query: postalCodeLevelGeneralResultsQuery,
   },
   [app.constants.dailyTotalsKey]: { fetch: fetchDailyTotals, push: pushDailyTotals, query: dailyTotalsQuery },
+
+  [app.constants.cityLevelDailyTotalsKey]: {
+    fetch: fetchCityLevelDailyTotals,
+    push: pushCityLevelDailyTotals,
+    query: postalCodeLevelDailyTotalsQuery,
+  },
 };
 
 interface CommonArgs {

--- a/src/backend/dataExports/cityLevelDailyTotals.ts
+++ b/src/backend/dataExports/cityLevelDailyTotals.ts
@@ -63,6 +63,7 @@ function mapCityLevelDailyTotals(
     cities: map(items, item => ({
       city: item.city,
       total: Number(item.responses),
+      population: item.population,
       ...collateDailyTotalItem(item as any),
     })),
   }));

--- a/src/backend/dataExports/cityLevelDailyTotals.ts
+++ b/src/backend/dataExports/cityLevelDailyTotals.ts
@@ -1,0 +1,108 @@
+import { fromPairs, groupBy, mapValues, map } from 'lodash';
+import { stringLiteralUnionFields, PostalCodeCityMappings, PopulationPerCity } from '../../common/model';
+import { App, s3PutJsonHelper } from '../app';
+import { mapResponseFieldsToQuery } from './queryUtils';
+import { accumulateResultsByCity } from './cityLevelGeneralResults';
+
+export async function exportCityLevelDailyTotals(app: App) {
+  const cityLevelDailyTotals = await fetchCityLevelDailyTotals(app);
+  await pushCityLevelDailyTotals(app, cityLevelDailyTotals);
+}
+
+export async function fetchCityLevelDailyTotals(app: App) {
+  const postalCodeLevelDailyTotalsResult = await queryPostalCodeLevelDailyTotals(app);
+
+  const postalCodeCityMappings = await app.s3Sources.fetchPostalCodeCityMappings();
+  const populationPerCity = await app.s3Sources.fetchPopulationPerCity();
+
+  const cityLevelDailyTotals = mapCityLevelDailyTotals(
+    postalCodeLevelDailyTotalsResult.Items,
+    postalCodeCityMappings,
+    populationPerCity,
+  );
+  return cityLevelDailyTotals;
+}
+
+interface PostalCodeLevelDailyTotalsQuery extends Record<string, string> {
+  day: string;
+  postal_code: string;
+  responses: string;
+}
+
+export const postalCodeLevelDailyTotalsQuery = `
+SELECT
+  SUBSTR(timestamp, 1, 10) AS day,
+  postal_code,
+  COUNT(*) AS responses,
+  ${mapResponseFieldsToQuery((field, value) => `  COUNT(IF(${field} = '${value}', 1, NULL)) AS ${field}_${value}`)}
+FROM responses WHERE (country_code = 'FI' or country_code = '')
+GROUP BY SUBSTR(timestamp, 1, 10), postal_code
+ORDER BY day
+`;
+
+async function queryPostalCodeLevelDailyTotals(app: App) {
+  return app.athenaClient.query<PostalCodeLevelDailyTotalsQuery>({
+    sql: postalCodeLevelDailyTotalsQuery,
+    db: app.constants.athenaDb,
+  });
+}
+
+function mapCityLevelDailyTotals(
+  postalCodeLevelDailyTotalsResult: PostalCodeLevelDailyTotalsQuery[],
+  postalCodeCityMappings: PostalCodeCityMappings,
+  populationPerCity: PopulationPerCity,
+) {
+  const resultsByDate = groupBy(postalCodeLevelDailyTotalsResult, item => item.day);
+
+  const a = mapValues(resultsByDate, items =>
+    accumulateResultsByCity(items as any, postalCodeCityMappings, populationPerCity),
+  );
+
+  const cityLevelDailyTotals = map(a, (items, day) => ({
+    day,
+    cities: map(items, item => ({
+      city: item.city,
+      total: Number(item.responses),
+      ...collateDailyTotalItem(item as any),
+    })),
+  }));
+
+  return cityLevelDailyTotals;
+}
+
+type CityLevelDailyTotals = ReturnType<typeof mapCityLevelDailyTotals>;
+
+// @example collateDailyTotalItem({
+//   day: '2020-03-26',
+//   total: '5823',
+//   fever_no: '5126',
+//   fever_slight: '623',
+//   fever_high: '74',
+//   ...
+// }) => {
+//   fever: { no: 5126, slight: 623, high: 74 },
+//   ...
+// }
+function collateDailyTotalItem(item: PostalCodeLevelDailyTotalsQuery) {
+  return fromPairs(
+    stringLiteralUnionFields
+      .filter(([field]) => field !== 'gender')
+      .map(([field, values]) => [field, fromPairs(values.map(value => [value, Number(item[`${field}_${value}`])]))]),
+  ) as any;
+}
+
+export async function pushCityLevelDailyTotals(app: App, cityLevelDailyTotals: CityLevelDailyTotals) {
+  return s3PutJsonHelper(app.s3Client, {
+    Bucket: app.constants.openDataBucket,
+    Key: app.constants.cityLevelDailyTotalsKey,
+    Body: {
+      meta: {
+        description:
+          'Population and daily response count per each city in Finland. Population data from Tilastokeskus. This data is released for journalistic and scientific purposes.',
+        generated: new Date().toISOString(),
+        link: `https://${app.constants.domainName}/${app.constants.cityLevelDailyTotalsKey}`,
+      },
+      data: cityLevelDailyTotals,
+    },
+  });
+}

--- a/src/backend/dataExports/cityLevelGeneralResults.ts
+++ b/src/backend/dataExports/cityLevelGeneralResults.ts
@@ -54,6 +54,8 @@ export interface CityLevelGeneralResult {
   stomach_issues_yes: number;
   sensory_issues_no: number;
   sensory_issues_yes: number;
+  healthcare_contact_yes: number;
+  healthcare_contact_no: number;
   longterm_medication_no: number;
   longterm_medication_yes: number;
   smoking_no: number;
@@ -118,6 +120,8 @@ export function accumulateResultsByCity(
       stomach_issues_yes: 0,
       sensory_issues_no: 0,
       sensory_issues_yes: 0,
+      healthcare_contact_yes: 0,
+      healthcare_contact_no: 0,
       longterm_medication_no: 0,
       longterm_medication_yes: 0,
       smoking_no: 0,
@@ -133,40 +137,41 @@ export function accumulateResultsByCity(
     const city = postalCodeCityMappings.data[postalCodeData.postal_code];
 
     if (!city || !(city in resultsByCity)) {
-      console.warn(`WARNING: accumulateResultsByCity: Skipping unknown postal code ${postalCodeData.postal_code}`);
       continue;
     }
 
-    resultsByCity[city].responses += Number(postalCodeData.responses);
-    resultsByCity[city].fever_no += Number(postalCodeData.fever_no);
-    resultsByCity[city].fever_slight += Number(postalCodeData.fever_slight);
-    resultsByCity[city].fever_high += Number(postalCodeData.fever_high);
-    resultsByCity[city].cough_no += Number(postalCodeData.cough_no);
-    resultsByCity[city].cough_mild += Number(postalCodeData.cough_mild);
-    resultsByCity[city].cough_intense += Number(postalCodeData.cough_intense);
-    resultsByCity[city].general_wellbeing_fine += Number(postalCodeData.general_wellbeing_fine);
-    resultsByCity[city].general_wellbeing_impaired += Number(postalCodeData.general_wellbeing_impaired);
-    resultsByCity[city].general_wellbeing_bad += Number(postalCodeData.general_wellbeing_bad);
-    resultsByCity[city].breathing_difficulties_no += Number(postalCodeData.breathing_difficulties_no);
-    resultsByCity[city].breathing_difficulties_yes += Number(postalCodeData.breathing_difficulties_yes);
-    resultsByCity[city].muscle_pain_no += Number(postalCodeData.muscle_pain_no);
-    resultsByCity[city].muscle_pain_yes += Number(postalCodeData.muscle_pain_yes);
-    resultsByCity[city].headache_no += Number(postalCodeData.headache_no);
-    resultsByCity[city].headache_yes += Number(postalCodeData.headache_yes);
-    resultsByCity[city].sore_throat_no += Number(postalCodeData.sore_throat_no);
-    resultsByCity[city].sore_throat_yes += Number(postalCodeData.sore_throat_yes);
-    resultsByCity[city].rhinitis_no += Number(postalCodeData.rhinitis_no);
-    resultsByCity[city].rhinitis_yes += Number(postalCodeData.rhinitis_yes);
-    resultsByCity[city].stomach_issues_no += Number(postalCodeData.stomach_issues_no);
-    resultsByCity[city].stomach_issues_yes += Number(postalCodeData.stomach_issues_yes);
-    resultsByCity[city].sensory_issues_no += Number(postalCodeData.sensory_issues_no);
-    resultsByCity[city].sensory_issues_yes += Number(postalCodeData.sensory_issues_yes);
-    resultsByCity[city].longterm_medication_no += Number(postalCodeData.longterm_medication_no);
-    resultsByCity[city].longterm_medication_yes += Number(postalCodeData.longterm_medication_yes);
-    resultsByCity[city].smoking_no += Number(postalCodeData.smoking_no);
-    resultsByCity[city].smoking_yes += Number(postalCodeData.smoking_yes);
-    resultsByCity[city].corona_suspicion_no += Number(postalCodeData.corona_suspicion_no);
-    resultsByCity[city].corona_suspicion_yes += Number(postalCodeData.corona_suspicion_yes);
+    resultsByCity[city].responses += Number(postalCodeData.responses) || 0;
+    resultsByCity[city].fever_no += Number(postalCodeData.fever_no) || 0;
+    resultsByCity[city].fever_slight += Number(postalCodeData.fever_slight) || 0;
+    resultsByCity[city].fever_high += Number(postalCodeData.fever_high) || 0;
+    resultsByCity[city].cough_no += Number(postalCodeData.cough_no) || 0;
+    resultsByCity[city].cough_mild += Number(postalCodeData.cough_mild) || 0;
+    resultsByCity[city].cough_intense += Number(postalCodeData.cough_intense) || 0;
+    resultsByCity[city].general_wellbeing_fine += Number(postalCodeData.general_wellbeing_fine) || 0;
+    resultsByCity[city].general_wellbeing_impaired += Number(postalCodeData.general_wellbeing_impaired) || 0;
+    resultsByCity[city].general_wellbeing_bad += Number(postalCodeData.general_wellbeing_bad) || 0;
+    resultsByCity[city].breathing_difficulties_no += Number(postalCodeData.breathing_difficulties_no) || 0;
+    resultsByCity[city].breathing_difficulties_yes += Number(postalCodeData.breathing_difficulties_yes) || 0;
+    resultsByCity[city].muscle_pain_no += Number(postalCodeData.muscle_pain_no) || 0;
+    resultsByCity[city].muscle_pain_yes += Number(postalCodeData.muscle_pain_yes) || 0;
+    resultsByCity[city].headache_no += Number(postalCodeData.headache_no) || 0;
+    resultsByCity[city].headache_yes += Number(postalCodeData.headache_yes) || 0;
+    resultsByCity[city].sore_throat_no += Number(postalCodeData.sore_throat_no) || 0;
+    resultsByCity[city].sore_throat_yes += Number(postalCodeData.sore_throat_yes) || 0;
+    resultsByCity[city].rhinitis_no += Number(postalCodeData.rhinitis_no) || 0;
+    resultsByCity[city].rhinitis_yes += Number(postalCodeData.rhinitis_yes) || 0;
+    resultsByCity[city].stomach_issues_no += Number(postalCodeData.stomach_issues_no) || 0;
+    resultsByCity[city].stomach_issues_yes += Number(postalCodeData.stomach_issues_yes) || 0;
+    resultsByCity[city].sensory_issues_no += Number(postalCodeData.sensory_issues_no) || 0;
+    resultsByCity[city].sensory_issues_yes += Number(postalCodeData.sensory_issues_yes) || 0;
+    resultsByCity[city].healthcare_contact_no += Number(postalCodeData.healthcare_contact_no) || 0;
+    resultsByCity[city].healthcare_contact_yes += Number(postalCodeData.healthcare_contact_yes) || 0;
+    resultsByCity[city].longterm_medication_no += Number(postalCodeData.longterm_medication_no) || 0;
+    resultsByCity[city].longterm_medication_yes += Number(postalCodeData.longterm_medication_yes) || 0;
+    resultsByCity[city].smoking_no += Number(postalCodeData.smoking_no) || 0;
+    resultsByCity[city].smoking_yes += Number(postalCodeData.smoking_yes) || 0;
+    resultsByCity[city].corona_suspicion_no += Number(postalCodeData.corona_suspicion_no) || 0;
+    resultsByCity[city].corona_suspicion_yes += Number(postalCodeData.corona_suspicion_yes) || 0;
   }
 
   return resultsByCity;
@@ -208,6 +213,8 @@ export function filterResultsByCity(resultsByCity: ResultsByCity, fn: (cityData:
         stomach_issues_yes: -1,
         sensory_issues_no: -1,
         sensory_issues_yes: -1,
+        healthcare_contact_yes: -1,
+        healthcare_contact_no: -1,
         longterm_medication_no: -1,
         longterm_medication_yes: -1,
         smoking_no: -1,

--- a/src/backend/dataExports/openDataIndex.ts
+++ b/src/backend/dataExports/openDataIndex.ts
@@ -9,6 +9,7 @@ const openDataConstantKeys: Array<keyof AppConstants> = [
   'cityLevelPastWeekGeneralResultsKey',
   'postalCodeLevelGeneralResultsKey',
   'dailyTotalsKey',
+  'cityLevelDailyTotalsKey',
   'lowPopulationPostalCodesKey',
   'populationPerCityKey',
   'postalCodeAreasKey',

--- a/src/backend/dataExports/postalCodeLevelGeneralResults.ts
+++ b/src/backend/dataExports/postalCodeLevelGeneralResults.ts
@@ -53,6 +53,8 @@ export interface PostalCodeLevelGeneralResultsQuery {
   stomach_issues_yes: string;
   sensory_issues_no: string;
   sensory_issues_yes: string;
+  healthcare_contact_yes: string;
+  healthcare_contact_no: string;
   longterm_medication_no: string;
   longterm_medication_yes: string;
   smoking_no: string;
@@ -86,6 +88,8 @@ export const postalCodeLevelGeneralResultsQuery = `SELECT postal_code,
   COUNT(IF ( stomach_issues = 'yes', 1, NULL)) AS stomach_issues_yes,
   COUNT(IF ( sensory_issues = 'no', 1, NULL)) AS sensory_issues_no,
   COUNT(IF ( sensory_issues = 'yes', 1, NULL)) AS sensory_issues_yes,
+  COUNT(IF ( healthcare_contact = 'no', 1, NULL)) AS healthcare_contact_no,
+  COUNT(IF ( healthcare_contact = 'yes', 1, NULL)) AS healthcare_contact_yes,
   COUNT(IF ( longterm_medication	 = 'no', 1, NULL)) AS longterm_medication_no,
   COUNT(IF ( longterm_medication	 = 'yes', 1, NULL)) AS longterm_medication_yes,
   COUNT(IF ( smoking	 = 'no', 1, NULL)) AS smoking_no,
@@ -134,6 +138,8 @@ export interface PostalCodeLevelGeneralResult {
   stomach_issues_yes: number;
   sensory_issues_no: number;
   sensory_issues_yes: number;
+  healthcare_contact_yes: number;
+  healthcare_contact_no: number;
   longterm_medication_no: number;
   longterm_medication_yes: number;
   smoking_no: number;
@@ -202,6 +208,8 @@ function accumulateResultsByPostalCode(
         stomach_issues_yes: 0,
         sensory_issues_no: 0,
         sensory_issues_yes: 0,
+        healthcare_contact_yes: 0,
+        healthcare_contact_no: 0,
         longterm_medication_no: 0,
         longterm_medication_yes: 0,
         smoking_no: 0,
@@ -222,36 +230,40 @@ function accumulateResultsByPostalCode(
       continue;
     }
 
-    resultsByPostalCode[postalCode].responses += Number(postalCodeData.responses);
-    resultsByPostalCode[postalCode].fever_no += Number(postalCodeData.fever_no);
-    resultsByPostalCode[postalCode].fever_slight += Number(postalCodeData.fever_slight);
-    resultsByPostalCode[postalCode].fever_high += Number(postalCodeData.fever_high);
-    resultsByPostalCode[postalCode].cough_no += Number(postalCodeData.cough_no);
-    resultsByPostalCode[postalCode].cough_mild += Number(postalCodeData.cough_mild);
-    resultsByPostalCode[postalCode].cough_intense += Number(postalCodeData.cough_intense);
-    resultsByPostalCode[postalCode].general_wellbeing_fine += Number(postalCodeData.general_wellbeing_fine);
-    resultsByPostalCode[postalCode].general_wellbeing_impaired += Number(postalCodeData.general_wellbeing_impaired);
-    resultsByPostalCode[postalCode].general_wellbeing_bad += Number(postalCodeData.general_wellbeing_bad);
-    resultsByPostalCode[postalCode].breathing_difficulties_no += Number(postalCodeData.breathing_difficulties_no);
-    resultsByPostalCode[postalCode].breathing_difficulties_yes += Number(postalCodeData.breathing_difficulties_yes);
-    resultsByPostalCode[postalCode].muscle_pain_no += Number(postalCodeData.muscle_pain_no);
-    resultsByPostalCode[postalCode].muscle_pain_yes += Number(postalCodeData.muscle_pain_yes);
-    resultsByPostalCode[postalCode].headache_no += Number(postalCodeData.headache_no);
-    resultsByPostalCode[postalCode].headache_yes += Number(postalCodeData.headache_yes);
-    resultsByPostalCode[postalCode].sore_throat_no += Number(postalCodeData.sore_throat_no);
-    resultsByPostalCode[postalCode].sore_throat_yes += Number(postalCodeData.sore_throat_yes);
-    resultsByPostalCode[postalCode].rhinitis_no += Number(postalCodeData.rhinitis_no);
-    resultsByPostalCode[postalCode].rhinitis_yes += Number(postalCodeData.rhinitis_yes);
-    resultsByPostalCode[postalCode].stomach_issues_no += Number(postalCodeData.stomach_issues_no);
-    resultsByPostalCode[postalCode].stomach_issues_yes += Number(postalCodeData.stomach_issues_yes);
-    resultsByPostalCode[postalCode].sensory_issues_no += Number(postalCodeData.sensory_issues_no);
-    resultsByPostalCode[postalCode].sensory_issues_yes += Number(postalCodeData.sensory_issues_yes);
-    resultsByPostalCode[postalCode].longterm_medication_no += Number(postalCodeData.longterm_medication_no);
-    resultsByPostalCode[postalCode].longterm_medication_yes += Number(postalCodeData.longterm_medication_yes);
-    resultsByPostalCode[postalCode].smoking_no += Number(postalCodeData.smoking_no);
-    resultsByPostalCode[postalCode].smoking_yes += Number(postalCodeData.smoking_yes);
-    resultsByPostalCode[postalCode].corona_suspicion_no += Number(postalCodeData.corona_suspicion_no);
-    resultsByPostalCode[postalCode].corona_suspicion_yes += Number(postalCodeData.corona_suspicion_yes);
+    resultsByPostalCode[postalCode].responses += Number(postalCodeData.responses) || 0;
+    resultsByPostalCode[postalCode].fever_no += Number(postalCodeData.fever_no) || 0;
+    resultsByPostalCode[postalCode].fever_slight += Number(postalCodeData.fever_slight) || 0;
+    resultsByPostalCode[postalCode].fever_high += Number(postalCodeData.fever_high) || 0;
+    resultsByPostalCode[postalCode].cough_no += Number(postalCodeData.cough_no) || 0;
+    resultsByPostalCode[postalCode].cough_mild += Number(postalCodeData.cough_mild) || 0;
+    resultsByPostalCode[postalCode].cough_intense += Number(postalCodeData.cough_intense) || 0;
+    resultsByPostalCode[postalCode].general_wellbeing_fine += Number(postalCodeData.general_wellbeing_fine) || 0;
+    resultsByPostalCode[postalCode].general_wellbeing_impaired +=
+      Number(postalCodeData.general_wellbeing_impaired) || 0;
+    resultsByPostalCode[postalCode].general_wellbeing_bad += Number(postalCodeData.general_wellbeing_bad) || 0;
+    resultsByPostalCode[postalCode].breathing_difficulties_no += Number(postalCodeData.breathing_difficulties_no) || 0;
+    resultsByPostalCode[postalCode].breathing_difficulties_yes +=
+      Number(postalCodeData.breathing_difficulties_yes) || 0;
+    resultsByPostalCode[postalCode].muscle_pain_no += Number(postalCodeData.muscle_pain_no) || 0;
+    resultsByPostalCode[postalCode].muscle_pain_yes += Number(postalCodeData.muscle_pain_yes) || 0;
+    resultsByPostalCode[postalCode].headache_no += Number(postalCodeData.headache_no) || 0;
+    resultsByPostalCode[postalCode].headache_yes += Number(postalCodeData.headache_yes) || 0;
+    resultsByPostalCode[postalCode].sore_throat_no += Number(postalCodeData.sore_throat_no) || 0;
+    resultsByPostalCode[postalCode].sore_throat_yes += Number(postalCodeData.sore_throat_yes) || 0;
+    resultsByPostalCode[postalCode].rhinitis_no += Number(postalCodeData.rhinitis_no) || 0;
+    resultsByPostalCode[postalCode].rhinitis_yes += Number(postalCodeData.rhinitis_yes) || 0;
+    resultsByPostalCode[postalCode].stomach_issues_no += Number(postalCodeData.stomach_issues_no) || 0;
+    resultsByPostalCode[postalCode].stomach_issues_yes += Number(postalCodeData.stomach_issues_yes) || 0;
+    resultsByPostalCode[postalCode].sensory_issues_no += Number(postalCodeData.sensory_issues_no) || 0;
+    resultsByPostalCode[postalCode].sensory_issues_yes += Number(postalCodeData.sensory_issues_yes) || 0;
+    resultsByPostalCode[postalCode].healthcare_contact_no += Number(postalCodeData.healthcare_contact_no) || 0;
+    resultsByPostalCode[postalCode].healthcare_contact_yes += Number(postalCodeData.healthcare_contact_yes) || 0;
+    resultsByPostalCode[postalCode].longterm_medication_no += Number(postalCodeData.longterm_medication_no) || 0;
+    resultsByPostalCode[postalCode].longterm_medication_yes += Number(postalCodeData.longterm_medication_yes) || 0;
+    resultsByPostalCode[postalCode].smoking_no += Number(postalCodeData.smoking_no) || 0;
+    resultsByPostalCode[postalCode].smoking_yes += Number(postalCodeData.smoking_yes) || 0;
+    resultsByPostalCode[postalCode].corona_suspicion_no += Number(postalCodeData.corona_suspicion_no) || 0;
+    resultsByPostalCode[postalCode].corona_suspicion_yes += Number(postalCodeData.corona_suspicion_yes) || 0;
   }
 
   return resultsByPostalCode;
@@ -296,6 +308,8 @@ export function filterResultsByPostalCode(
         stomach_issues_yes: -1,
         sensory_issues_no: -1,
         sensory_issues_yes: -1,
+        healthcare_contact_yes: -1,
+        healthcare_contact_no: -1,
         longterm_medication_no: -1,
         longterm_medication_yes: -1,
         smoking_no: -1,

--- a/src/backend/dataExports/queryUtils.test.ts
+++ b/src/backend/dataExports/queryUtils.test.ts
@@ -1,0 +1,43 @@
+import { mapResponseFieldsToQuery } from './queryUtils';
+
+describe('mapResponseFieldsToQuery', () => {
+  it('maps fields to IF statements', () => {
+    const fields = mapResponseFieldsToQuery((field, value) => `IF(${field} = '${value}', 1, 0) AS ${field}_${value}`);
+    expect(fields).toEqual(
+      `IF(fever = 'no', 1, 0) AS fever_no,
+    IF(fever = 'slight', 1, 0) AS fever_slight,
+    IF(fever = 'high', 1, 0) AS fever_high,
+    IF(cough = 'no', 1, 0) AS cough_no,
+    IF(cough = 'mild', 1, 0) AS cough_mild,
+    IF(cough = 'intense', 1, 0) AS cough_intense,
+    IF(breathing_difficulties = 'yes', 1, 0) AS breathing_difficulties_yes,
+    IF(breathing_difficulties = 'no', 1, 0) AS breathing_difficulties_no,
+    IF(muscle_pain = 'yes', 1, 0) AS muscle_pain_yes,
+    IF(muscle_pain = 'no', 1, 0) AS muscle_pain_no,
+    IF(headache = 'yes', 1, 0) AS headache_yes,
+    IF(headache = 'no', 1, 0) AS headache_no,
+    IF(sore_throat = 'yes', 1, 0) AS sore_throat_yes,
+    IF(sore_throat = 'no', 1, 0) AS sore_throat_no,
+    IF(rhinitis = 'yes', 1, 0) AS rhinitis_yes,
+    IF(rhinitis = 'no', 1, 0) AS rhinitis_no,
+    IF(stomach_issues = 'yes', 1, 0) AS stomach_issues_yes,
+    IF(stomach_issues = 'no', 1, 0) AS stomach_issues_no,
+    IF(sensory_issues = 'yes', 1, 0) AS sensory_issues_yes,
+    IF(sensory_issues = 'no', 1, 0) AS sensory_issues_no,
+    IF(healthcare_contact = 'yes', 1, 0) AS healthcare_contact_yes,
+    IF(healthcare_contact = 'no', 1, 0) AS healthcare_contact_no,
+    IF(general_wellbeing = 'fine', 1, 0) AS general_wellbeing_fine,
+    IF(general_wellbeing = 'impaired', 1, 0) AS general_wellbeing_impaired,
+    IF(general_wellbeing = 'bad', 1, 0) AS general_wellbeing_bad,
+    IF(longterm_medication = 'yes', 1, 0) AS longterm_medication_yes,
+    IF(longterm_medication = 'no', 1, 0) AS longterm_medication_no,
+    IF(smoking = 'yes', 1, 0) AS smoking_yes,
+    IF(smoking = 'no', 1, 0) AS smoking_no,
+    IF(corona_suspicion = 'yes', 1, 0) AS corona_suspicion_yes,
+    IF(corona_suspicion = 'no', 1, 0) AS corona_suspicion_no,
+    IF(gender = 'female', 1, 0) AS gender_female,
+    IF(gender = 'male', 1, 0) AS gender_male,
+    IF(gender = 'other', 1, 0) AS gender_other`.replace(/^\s+/gm, ''),
+    );
+  });
+});

--- a/src/backend/dataExports/queryUtils.ts
+++ b/src/backend/dataExports/queryUtils.ts
@@ -1,0 +1,23 @@
+import { flatten } from 'lodash';
+import { stringLiteralUnionFields } from '../../common/model';
+
+/**
+ * Form a list of query fields from response models union fields
+ *
+ * @example
+ * ```js
+ * mapResponseFieldsToQuery((field, value) =>
+ *  `IF(${field} = '${value}', 1, 0) AS ${field}_${value}`
+ * )
+ * ```
+ * Output:
+ * ```sql
+ * IF(fever = 'no', 1, 0) AS fever_no,
+ * IF(fever = 'slight', 1, 0) AS fever_slight,
+ * IF(fever = 'high', 1, 0) AS fever_high,
+ * ...
+ * ```
+ */
+export function mapResponseFieldsToQuery(fn: (field: string, value: string) => string) {
+  return flatten(stringLiteralUnionFields.map(([field, values]) => values.map(value => fn(field, value)))).join(',\n');
+}

--- a/src/backend/dataExports/totalResponses.ts
+++ b/src/backend/dataExports/totalResponses.ts
@@ -18,7 +18,7 @@ interface TotalResponsesQuery {
   total_responses: string;
 }
 
-const totalResponsesQuery = 'SELECT COUNT(*) as total_responses FROM responses';
+export const totalResponsesQuery = 'SELECT COUNT(*) as total_responses FROM responses';
 
 export async function queryTotalResponses(app: App) {
   return app.athenaClient.query<TotalResponsesQuery>({ sql: totalResponsesQuery, db: app.constants.athenaDb });


### PR DESCRIPTION
Closes #299 

City level daily totals data dump

- Adds new `city_level_daily_totals.json` open data file
- Adds `healthcare_contact` field to city and postal code sets
- Fixes `null`-field issues with accumulated data
- Postal codes/cities are filtered as in city-level general results:
  - Postal codes are mapped using `low_population_postal_codes.json`
  - Postal codes and cities not found in `population_per_city.json` are ignored