### PR TITLE
Change backend worker process to run once per day

### DIFF
--- a/infra/modules/main/backend.tf
+++ b/infra/modules/main/backend.tf
@@ -49,8 +49,8 @@ module "backend_worker" {
   function_s3_bucket     = aws_s3_bucket.backend_code.id
   function_zipfile       = "backend-lambda.zip"
   function_handler       = "index.workerEntrypoint"
-  function_timeout       = 60 * 10                     # i.e. 10 minutes
-  schedule_expression    = "cron(0 0,6,12,18 * * ? *)" # as in (Minutes Hours Day-of-month Month Day-of-week Year); see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+  function_timeout       = 60 * 10             # i.e. 10 minutes
+  schedule_expression    = "cron(0 3 * * ? *)" # as in (Minutes Hours Day-of-month Month Day-of-week Year); see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
   lambda_logging_enabled = true
   function_env_vars      = local.lambda_env
 }


### PR DESCRIPTION
Looking at our costs, they're dominated by storage:

![image](https://user-images.githubusercontent.com/560055/82799154-417efd80-9e82-11ea-8a3e-da5162bda020.png)

...which means S3:

![image](https://user-images.githubusercontent.com/560055/82799207-59568180-9e82-11ea-8f02-ecdf83562c50.png)

...which should mostly be Athena scanning the data.

I don't think anyone minds a bit of delay in the results at this point.