### PR TITLE
Auto resize overview embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ If the map view is edited, the embed version should also be tested. Locally you 
 
 #### Overview embed
 
-Overview view has tow router paths, `/overview` and `/map-embed/overview`. Although this view comes as an integrated part as the main site, it should be separated from the map in `/map-embed`. This translates to not showing any visible link in Overview that allows users to navigate to the Map view while in embed mode. In case the article needs to show both Overview and Map, it'll be ideal to have two separate iframes.
+Overview view has tow router paths, `/overview` and `/map-embed/overview`. Although this view comes as an integrated part as the main site, it should be separated from the map in `/map-embed`. This translates to not showing any visible link in Overview that allows users to navigate to the map view while in embed. In case the article needs to show both Overview and Map, two separate iframes will be needed.
 
-The reason for this is because Overview provides support for `iframeResizer` by dynamically importing `iframe-resizer/js/iframeResizer.contentWindow` when the view is loaded, activating auto-resizing for the iframe. Subsequently, navigating to the Map view from Overview would cause the Map view to adapt to the size of previous Overview view, since Map does not have any fixed height.
+The reason for this is because Overview provides support for `iframeResizer` by dynamically importing `iframe-resizer/js/iframeResizer.contentWindow` when the view is loaded, activating auto-resizing for the iframe. Subsequently, navigating to the Map view from Overview would also trigger auto-resizing for Map, causing the view to collapse because Map does not have a fixed height and will try to adapt to its container's sizes.
 
 #### Survey page
 

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ If the map view is edited, the embed version should also be tested. Locally you 
 
 #### Overview embed
 
-Overview view has tow router paths, `/overview` and `/map-embed/overview`. Although this view comes as an integrated part as the main site, it should be separated from the map in `/map-embed`. This translates to not showing any visible link in Overview that allows users to navigate to the Map view while in embed mode. In case the article needs to show both Overview and Map, two separate iframes will be needed.
+Overview view has tow router paths, `/overview` and `/map-embed/overview`. Although this view comes as an integrated part as the main site, it should be separated from the map in `/map-embed`. This translates to not showing any visible link in Overview that allows users to navigate to the Map view while in embed mode. In case the article needs to show both Overview and Map, it'll be ideal to have two separate iframes.
 
-The reason for this is because Overview provides support for `iframeResizer` by dynamically importing `iframe-resizer/js/iframeResizer.contentWindow` when the view is loaded, activating auto-resizing for the iframe. Subsequently, navigating to the Map view from Overview would also trigger auto-resizing for Map, causing the view to collapse because Map does not have a fixed height and tries to adapt to its container's sizes.
+The reason for this is because Overview provides support for `iframeResizer` by dynamically importing `iframe-resizer/js/iframeResizer.contentWindow` when the view is loaded, activating auto-resizing for the iframe. Subsequently, navigating to the Map view from Overview would cause the Map view to adapt to the size of previous Overview view, since Map does not have any fixed height.
 
 #### Survey page
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ The main difference with the normal version and the embed is that the embed does
 
 If the map view is edited, the embed version should also be tested. Locally you can check `/map-embed`. It's good to also test within an iframe (ask the team for a test article link). Also keep in mind that the updates will go to all news articles where the embed is already included.
 
+#### Overview embed
+
+Overview view has tow router paths, `/overview` and `/map-embed/overview`. Although this view comes as an integrated part as the main site, it should be separated from the map in `/map-embed`. This translates to not showing any visible link in Overview that allows users to navigate to the Map view while in embed mode. In case the article needs to show both Overview and Map, two separate iframes will be needed.
+
+The reason for this is because Overview provides support for `iframeResizer` by dynamically importing `iframe-resizer/js/iframeResizer.contentWindow` when the view is loaded, activating auto-resizing for the iframe. Subsequently, navigating to the Map view from Overview would also trigger auto-resizing for Map, causing the view to collapse because Map does not have a fixed height and tries to adapt to its container's sizes.
+
 #### Survey page
 
 The embedded form on the survey page does not work locally, the iframe does not load the correct content there. If you want to test it, you can for example temporarily change the relative path in `Survey.tsx` to point in dev

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If the map view is edited, the embed version should also be tested. Locally you 
 
 #### Overview embed
 
-Overview view has tow router paths, `/overview` and `/map-embed/overview`. Although this view comes as an integrated part as the main site, it should be separated from the map in `/map-embed`. This translates to not showing any visible link in Overview that allows users to navigate to the map view while in embed. In case the article needs to show both Overview and Map, two separate iframes will be needed.
+Overview view has two router paths, `/overview` and `/map-embed/overview`. Although this view comes as an integrated part as the main site, it should be separated from the map in `/map-embed`. This translates to not showing any visible link in Overview that allows users to navigate to the map view while in embed. In case the article needs to show both Overview and Map, two separate iframes will be needed.
 
 The reason for this is because Overview provides support for `iframeResizer` by dynamically importing `iframe-resizer/js/iframeResizer.contentWindow` when the view is loaded, activating auto-resizing for the iframe. Subsequently, navigating to the Map view from Overview would also trigger auto-resizing for Map, causing the view to collapse because Map does not have a fixed height and will try to adapt to its container's sizes.
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -26,7 +26,7 @@ module "env_dev" {
 module "env_prod" {
   # IMPORTANT: The prod environment is pinned to the latest release version, so it won't change during normal development.
   # See infra/README.md for how to deal with it during releases, when actual prod infra changes need to be made.
-  source    = "git::ssh://git@github.com/futurice/symptomradar.git//infra/modules/main?ref=v2.7"
+  source    = "git::ssh://git@github.com/futurice/symptomradar.git//infra/modules/main?ref=v2.8"
   providers = { aws.us_east_1 = aws.us_east_1 } # this alias is needed because ACM is only available in the "us-east-1" region
 
   name_prefix          = "${var.name_prefix}-prod"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -26,7 +26,7 @@ module "env_dev" {
 module "env_prod" {
   # IMPORTANT: The prod environment is pinned to the latest release version, so it won't change during normal development.
   # See infra/README.md for how to deal with it during releases, when actual prod infra changes need to be made.
-  source    = "git::ssh://git@github.com/futurice/symptomradar.git//infra/modules/main?ref=v2.8"
+  source    = "git::ssh://git@github.com/futurice/symptomradar.git//infra/modules/main?ref=v2.7"
   providers = { aws.us_east_1 = aws.us_east_1 } # this alias is needed because ACM is only available in the "us-east-1" region
 
   name_prefix          = "${var.name_prefix}-prod"

--- a/src/frontend/main/MainWrapper.tsx
+++ b/src/frontend/main/MainWrapper.tsx
@@ -176,7 +176,7 @@ const MainWrapper = (props: MainWrapperProps) => {
        * Route structure for stat views:
        * ==============================
        * /         -> MapView
-       * /overview -> MapView
+       * /overview -> Overview
        * /cities   -> TableView
        * /map-embed/         -> MapView
        * /map-embed/overview -> OverView

--- a/src/frontend/main/Overview/index.tsx
+++ b/src/frontend/main/Overview/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { RouteComponentProps, Link } from '@reach/router';
@@ -135,6 +135,23 @@ const Overview = (props: OverviewProps) => {
     .map((item: any) => {
       return item.city;
     });
+
+  useEffect(() => {
+    // Add support for articles that already has iframe-resizer/js/iframeResizer
+    // parent running.
+    // Using dynamic import to make sure the script iframeResizer.contentWindow
+    // is only loaded when this view loads.
+    // Since the parent articles that are embedding this page via iframe
+    // already have `iframe-resizer/js/iframeResizer` running and waiting, having
+    // `iframe-resizer/js/iframeResizer.contentWindow` included in the main bundle,
+    // a.k.a using the normal `import ....` syntax at the top of the file,
+    // would unwantedly triggers autoresizing for all other views - incuding
+    // MapView and CitiesView - which should expect a fixed height iframe instead.
+    if (props.isEmbed) {
+      import('iframe-resizer/js/iframeResizer.contentWindow');
+    }
+  }, [props.isEmbed]);
+
   return (
     <Container>
       <CitySelect>

--- a/src/frontend/main/Overview/index.tsx
+++ b/src/frontend/main/Overview/index.tsx
@@ -208,14 +208,16 @@ const Overview = (props: OverviewProps) => {
         </select>
       </CitySelect>
       <Body data={dataForSelectedCity} city={selectedCity} />
-      <MobilePadding>
-        <OverviewFooter>
-          <MapLink to={mapPath}>
-            {t('main:goToMap')}
-            <RightArrowIcon fillColor={theme.white} />
-          </MapLink>
-        </OverviewFooter>
-      </MobilePadding>
+      {!props.isEmbed && (
+        <MobilePadding>
+          <OverviewFooter>
+            <MapLink to={mapPath}>
+              {t('main:goToMap')}
+              <RightArrowIcon fillColor={theme.white} />
+            </MapLink>
+          </OverviewFooter>
+        </MobilePadding>
+      )}
     </Container>
   );
 };

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -7,3 +7,5 @@ declare module '*.svg';
 // We can't import the whole "iframe-resizer" library, so its typings aren't useful to us, either.
 // See the import "iframe-resizer/js/iframeResizer" for details.
 declare module 'iframe-resizer/js/iframeResizer';
+// And the import "iframe-resizer/js/iframeResizer.contentWindow" for details.
+declare module 'iframe-resizer/js/iframeResizer.contentWindow';


### PR DESCRIPTION
- Add iframe resize support for Overview embed
- Fix comment about the map view router structure `/overview -> Overview` instead of `/overview -> MapView`
- Add Overview embed section in README

To test, we could modify the `Survey.tsx` file (which already has iframeResizer "parent" part loaded).

Change the Survey component's code to:

```
const Survey = (props: RouteComponentProps) => {
  const [iframeSrc, setIframeSrc] = useState('/embed/v1/?variant=plain');
  const currentLanguage = i18n.language;

  useEffect(() => {
    iframeResizer({ log: false }, '.formIframe');
    const newUrl =
      currentLanguage === 'fi' ? 'http://localhost:3000/map-embed/overview' : 'http://localhost:3000/map-embed';
    setIframeSrc(newUrl);
  }, [currentLanguage]);

  return (
    <Container>
      <Iframe className="formIframe" title="Map embed" src="http://localhost:3000/map-embed" height="400px" />
      <Iframe className="formIframe" title="Oiretutka-kysely" src={iframeSrc} />
    </Container>
  );
};
```

Both iframes are set with fixed heights, but map content height should stay at 400px, indicating that `iframe-resizer/js/iframeResizer.contentWindow` is not activated there.

Hold your breath before clicking `Karttaan` button at the bottom of Overview 