### PR TITLE
Position timeline filter at the bottom of the iframe in embed mode

### DIFF
--- a/src/frontend/main/FilterToggle.tsx
+++ b/src/frontend/main/FilterToggle.tsx
@@ -48,12 +48,14 @@ type CompareFilterToggleProps = {
   firstSelectedFilter: Symptom;
   secondSelectedFilter: Symptom;
   handleFilterChange: (firstFilter: Symptom, secondFilter: Symptom) => void;
+  isEmbed: boolean;
 };
 
 export const CompareFilterToggle = ({
   firstSelectedFilter,
   secondSelectedFilter,
   handleFilterChange,
+  isEmbed,
 }: CompareFilterToggleProps) => {
   const { isShowing, toggleModal } = useModal();
   const { t } = useTranslation(['main']);
@@ -63,7 +65,7 @@ export const CompareFilterToggle = ({
       <FilterButton type="button" handleClick={toggleModal} label={t('main:filter')}>
         <FilterIcon />
       </FilterButton>
-      <Modal isShowing={isShowing} hide={toggleModal} ariaLabel={t('main:filterDialogTitle')}>
+      <Modal isShowing={isShowing} hide={toggleModal} ariaLabel={t('main:filterDialogTitle')} positionBottom={isEmbed}>
         <CompareFilters
           firstSelectedFilter={firstSelectedFilter}
           secondSelectedFilter={secondSelectedFilter}

--- a/src/frontend/main/FilterToggle.tsx
+++ b/src/frontend/main/FilterToggle.tsx
@@ -65,6 +65,12 @@ export const CompareFilterToggle = ({
       <FilterButton type="button" handleClick={toggleModal} label={t('main:filter')}>
         <FilterIcon />
       </FilterButton>
+      {/* In case of embedded iframe, we havea very long overview page, and the modal
+       * will be centerred to the iframe's height, but not with respect to the device's
+       * screen sizes. That means there will be cases where the modal appear on top of
+       * the screen while in embed. So placing the modal at the bottom of the iframe seems
+       * to be a more ideal location.
+       * */}
       <Modal isShowing={isShowing} hide={toggleModal} ariaLabel={t('main:filterDialogTitle')} positionBottom={isEmbed}>
         <CompareFilters
           firstSelectedFilter={firstSelectedFilter}

--- a/src/frontend/main/Modal.tsx
+++ b/src/frontend/main/Modal.tsx
@@ -9,11 +9,12 @@ type ModalProps = {
   isShowing: boolean;
   hide: () => void;
   ariaLabel: string;
+  positionBottom?: boolean;
 };
 
-const ModalOverlay = styled(DialogOverlay)`
+const ModalOverlay = styled(DialogOverlay)<{ positionBottom?: boolean }>`
   display: flex;
-  align-items: center;
+  align-items: ${({ positionBottom = false }) => (positionBottom ? 'flex-end' : 'center')};
   justify-content: center;
 `;
 
@@ -22,6 +23,7 @@ const ModalDialogContent = styled(DialogContent)`
   position: relative;
   width: 100%;
   max-width: 95vw;
+  margin: 2vh 0;
 
   @media (min-width: 520px) {
     max-width: 500px;
@@ -44,10 +46,10 @@ const ModalCloseButton = styled.button`
   }
 `;
 
-const Modal: React.FC<ModalProps> = ({ isShowing, hide, children, ariaLabel }) => {
+const Modal: React.FC<ModalProps> = ({ isShowing, hide, children, ariaLabel, positionBottom = false }) => {
   const { t } = useTranslation(['main']);
   return (
-    <ModalOverlay isOpen={isShowing} onDismiss={hide}>
+    <ModalOverlay isOpen={isShowing} onDismiss={hide} positionBottom={positionBottom}>
       <ModalDialogContent aria-label={ariaLabel}>
         <ModalCloseButton type="button" aria-label={t('main:close')} onClick={hide}>
           <CloseIcon />

--- a/src/frontend/main/Overview/Body.tsx
+++ b/src/frontend/main/Overview/Body.tsx
@@ -126,7 +126,7 @@ const Div = styled.div`
   background-color: #fafafa;
   font-style: italic;
 `;
-const Body: React.FunctionComponent<{ data: any; city: string }> = props => {
+const Body: React.FunctionComponent<{ data: any; city: string; isEmbed: boolean }> = props => {
   const currentLocale = getCurrentLocale();
   const { t } = useTranslation(['main']);
   const [[timeSeriesWidth, timeSeriesHeight], setTimeSeriesSizes] = useState<[number, number]>([
@@ -177,6 +177,7 @@ const Body: React.FunctionComponent<{ data: any; city: string }> = props => {
           firstSelectedFilter={selectedSymptomFirstLine}
           secondSelectedFilter={selectedSymptomSecondLine}
           handleFilterChange={setSelectedSymptoms}
+          isEmbed={props.isEmbed}
         />
       </FiltersWrapper>
 

--- a/src/frontend/main/Overview/index.tsx
+++ b/src/frontend/main/Overview/index.tsx
@@ -207,7 +207,7 @@ const Overview = (props: OverviewProps) => {
           })}
         </select>
       </CitySelect>
-      <Body data={dataForSelectedCity} city={selectedCity} />
+      <Body data={dataForSelectedCity} city={selectedCity} isEmbed={props.isEmbed} />
       {!props.isEmbed && (
         <MobilePadding>
           <OverviewFooter>


### PR DESCRIPTION
We try to center the dialog into the device's screen, but in case of iframe, the whole iframe's length is taken into account instead of the device's screen size, so the modal is cut off from the screen, resulting in something like this.

![image](https://user-images.githubusercontent.com/6004147/83236785-c167d900-a19c-11ea-85ef-4eab4531643b.png)

Firefox seems to respect the focus set to close button when the modal opens, and manages to scroll back to fit the modal to the top of the page, but this is not the case for Chrome : (

So I decided to place the Timeline modal al the bottom of the page if it is embedded.

![image](https://user-images.githubusercontent.com/6004147/83236964-1a377180-a19d-11ea-9ef2-f7535a83ee8b.png)
